### PR TITLE
Feature/shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ deploy: build
 		./ $(REMOTE):$(REMOTE_DIR)/
 
 # -----------------------------
+# Update on device
+# -----------------------------
+update:
+	ssh $(REMOTE) "cd $(REMOTE_DIR) && ./update.sh"
+
+# -----------------------------
 # Install on device
 # -----------------------------
 install:
@@ -68,5 +74,15 @@ release: bump-patch deploy install
 	@git push
 	@git push --tags
 
+# -----------------------------
+# Remove version file
+# -----------------------------
 clean:
 	rm -f VERSION
+
+# -----------------------------
+# Check version on device
+# -----------------------------
+device-version:
+	@echo "Device version:"
+	@ssh $(REMOTE) "cd $(REMOTE_DIR) && cat VERSION"

--- a/radioglobe/main.py
+++ b/radioglobe/main.py
@@ -131,7 +131,18 @@ class App:
     def switch_mode(self):
         """Toggle between application modes."""
         self.state.mode = "city" if self.state.mode == "station" else "station"
-        self.state.jog_idx = 0
+        if self.state.mode == "city":
+            self.state.jog_idx = (
+                self.state.cities.index(self.state.city)
+                if self.state.city in self.state.cities
+                else 0
+            )
+        else:
+            self.state.jog_idx = (
+                self.state.stations.index(self.state.station)
+                if self.state.station in self.state.stations
+                else 0
+            )
         logging.debug(
             f"🌀 Mode switched to: {self.state.mode} jog:{self.state.jog_idx} "
             f"{self.state.city} {self.state.station}"

--- a/radioglobe/main.py
+++ b/radioglobe/main.py
@@ -317,9 +317,9 @@ class App:
             f"Encoder offsets set to: {self.encoders.latitude}, {self.encoders.longitude} "
             f"{self.encoders.latitude_offset}, {self.encoders.longitude_offset}"
         )
-        self.display.update(Coordinate(0, 0), "Calibrated", 0, "", False)
-        await asyncio.sleep(0.5)
-        self.display.update(Coordinate(0, 0), "CALIBRATE", 0, "", False)
+        self.display.update(Coordinate(0, 0), "Calibrating", 0, "", False)
+        await asyncio.sleep(2)
+        self.display.update(Coordinate(0, 0), "CALIBRATED", 0, "", False)
 
     async def _handle_long_mid(self):
         logging.debug("🔴 Shutdown initiated! Powering off...")

--- a/radioglobe/main.py
+++ b/radioglobe/main.py
@@ -325,8 +325,12 @@ class App:
         logging.debug("🔴 Shutdown initiated! Powering off...")
         self.save_state()
         logging.debug("Saved state...")
-        self.display.update(Coordinate(0, 0), "Shutdown", 0, "", False)
+        coords = self._get_coords_by_city(self.state.city) if self.state.city else Coordinate(0, 0)
+        self.display.update(coords, "Shutdown", 0, "", False)
         await asyncio.sleep(2)
+        if self.state.city and self.state.station:
+            self.display.update(coords, self.state.city, 0, self.state.station[0], False)
+        await asyncio.sleep(0.5)
         subprocess.run(["sudo", "poweroff"])
 
     # ---------------------------------------------------------------------------

--- a/radioglobe/radio_config.py
+++ b/radioglobe/radio_config.py
@@ -6,7 +6,7 @@ ENCODER_RESOLUTION = 1024
 
 # Higher values of fuzziness increases the search area.
 # May include more than one city may be included if they are located close together.
-FUZZINESS = 5
+FUZZINESS = 3
 
 # Affects ability to latch on to cities
 STICKINESS = 2

--- a/radioglobe/radio_config.py
+++ b/radioglobe/radio_config.py
@@ -32,4 +32,4 @@ I2C_LCD_ADDR   = 0x27
 STATE_CACHE_PATH = "~/cache/radioglobe.json"
 
 # Logging
-LOG_LEVEL = "INFO"
+LOG_LEVEL = "DEBUG"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+RADIOGLOBE_USER=radioglobe
+RADIOGLOBE_DIR=/opt/radioglobe
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "🚀 Updating RadioGlobe..."
+echo "Safe for small code changes only"
+
+# -----------------------------
+# Version (injected from dev machine)
+# -----------------------------
+if [[ -f "$SRC_DIR/VERSION" ]]; then
+    VERSION=$(cat "$SRC_DIR/VERSION")
+else
+    VERSION="unknown"
+fi
+
+echo "📦 Version: $VERSION"
+
+# -----------------------------
+# Prepare install directory
+# -----------------------------
+echo "📁 Preparing install dir..."
+sudo mkdir -p $RADIOGLOBE_DIR
+sudo chown -R $RADIOGLOBE_USER:$RADIOGLOBE_USER $RADIOGLOBE_DIR
+
+# -----------------------------
+# Copy application (SAFE: no delete)
+# -----------------------------
+echo "📂 Copying application..."
+sudo cp -r "$SRC_DIR/radioglobe" "$RADIOGLOBE_DIR/"
+
+# Stations + version
+sudo mkdir -p "$RADIOGLOBE_DIR/stations"
+sudo cp "$SRC_DIR/stations/stations.json" "$RADIOGLOBE_DIR/stations/"
+sudo cp "$SRC_DIR/VERSION" "$RADIOGLOBE_DIR/VERSION"
+
+sudo chown -R $RADIOGLOBE_USER:$RADIOGLOBE_USER $RADIOGLOBE_DIR
+
+# -----------------------------
+# Install systemd user service
+# -----------------------------
+echo "⚙️ Installing service..."
+
+SERVICE_FILE=/etc/systemd/user/radioglobe.service
+sudo cp "$SRC_DIR/services/radioglobe.service" $SERVICE_FILE
+
+sudo sed -i "s|__RADIOGLOBE_DIR__|$RADIOGLOBE_DIR|g" $SERVICE_FILE
+sudo sed -i "s|__VERSION__|$VERSION|g" $SERVICE_FILE
+
+# -----------------------------
+# Enable lingering (required for user services)
+# -----------------------------
+echo "🔑 Enabling lingering..."
+sudo loginctl enable-linger $RADIOGLOBE_USER
+
+# -----------------------------
+# Enable service (DO NOT start here)
+# -----------------------------
+USER_ID=$(id -u $RADIOGLOBE_USER)
+export XDG_RUNTIME_DIR=/run/user/$USER_ID
+
+echo "🔄 Enabling service..."
+
+sudo -u $RADIOGLOBE_USER \
+    XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
+    systemctl --user daemon-reload
+
+sudo -u $RADIOGLOBE_USER \
+    XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
+    systemctl --user enable radioglobe.service
+
+echo "✅ Installation updated!"
+echo "⚠️ Restart service on Radioglobe"
+echo "   systemctl --user restart radioglobe.service"
+echo "📖 Logs after reboot:"
+echo "   journalctl --user-unit=radioglobe.service -f"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                     
                                                                                                                                                                                                                               
  - **Shutdown display**: Show city coords on the "Shutdown" splash, then restore the normal city/station display for 0.5 s before `poweroff` executes                                                                           
  - **Calibration feedback**: Extend calibration display to 2 s and show "Calibrating" → "CALIBRATED" sequence                                                                                                                   
  - **Mode-switch fix**: When toggling station ↔ city mode, initialise `jog_idx` to the current item's actual position in the list rather than always resetting to 0 — fixes the bug where the first dial turn after switching to
   city mode changed the station instead of the city                                                                                                                                                                             
  - **Default tuning**: Reduce `FUZZINESS` from 5 → 3; set default `LOG_LEVEL` to `DEBUG`                                                                                                                                        
  - **Deployment**: Add `update.sh` for lightweight on-device updates; add `make update` and `make device-version` targets                                                                                                       
                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                   
                                                                                                                                                                                                                                 
  - [ ] Hold mid button — confirm "Shutdown" appears with correct coords, then city/station display restores briefly before poweroff                                                                                             
  - [ ] Short-press mid button — confirm "Calibrating" then "CALIBRATED" sequence                                                                                                                                                
  - [ ] Switch to city mode (short jog press), turn dial — confirm city changes on the first turn                                                                                                                                
  - [ ] Run `make update` from dev machine and verify version updates on device