### PR TITLE
Guard against IndexError when a latched/selected city has no stations

### DIFF
--- a/radioglobe/main.py
+++ b/radioglobe/main.py
@@ -262,6 +262,10 @@ class App:
                 self.state.city = self.state.cities[0]
                 self._current_coords = self._get_coords_by_city(self.state.city)
                 self.state.stations = get_stations_by_city(self.stations_info, self.state.city)
+                if not self.state.stations:
+                    logging.warning(f"No stations for {self.state.city!r} — skipping latch")
+                    self.encoders.reset_latch()
+                    continue
                 self.state.station = self.state.stations[0]
                 logging.info(f"Cities: {self.state.cities}")
                 logging.debug(
@@ -286,6 +290,9 @@ class App:
                 self.next_station(direction)
             elif self.state.mode == "city":
                 self.next_city(direction)
+                if not self.state.stations:
+                    logging.warning(f"No stations for {self.state.city!r} — keeping previous station")
+                    continue
                 self.state.station = self.state.stations[0]
 
             coords = self._current_coords or self._get_coords_by_city(self.state.city)


### PR DESCRIPTION
## Summary
- `self.state.stations[0]` was indexed unconditionally in `_encoder_loop()` (right after latching a city) and `_dial_loop()` (right after `next_city()`). A city in `stations.json` with an empty/missing `urls` list crashed the owning asyncio task with an unhandled `IndexError`, silently killing reticule or dial input until the app was restarted.
- Both call sites now guard on an empty stations list, log a warning, and skip to the next event. `_encoder_loop()` also releases the latch (`reset_latch()`) so the reticule can search again instead of staying frozen on a dead city.
- Matches the fix already documented in `ARCHITECTURE.md`'s Suggested Improvements (Improvement A).

## Test plan
- [x] `uv run pytest` — 4 passed
- [x] `ruff check radioglobe/main.py` — clean
- [x] Deployed to real hardware (`radioglobe.local`) and verified on-device: a throwaway script (mocking only the hardware-touching classes so it never conflicts with the live service) constructed a real `App()`, injected a test city with an empty station list, and called the actual unmodified `_encoder_loop()`/`_dial_loop()` methods directly.
  - `_encoder_loop()`: task did not crash, `reset_latch()` was called, `state.station` stayed `None`.
  - `_dial_loop()`: task did not crash, `state.city` updated to the empty-station city but `state.station` stayed on the previous, valid station.
- No new unit test added: `App` instantiates real GPIO/SPI/I2C/VLC hardware in `__init__`, and `radioglobe.main` cannot even be imported off a Raspberry Pi (`RPi.GPIO` raises `RuntimeError`), so these loops aren't reachable from the existing unit test suite (which only covers `database.py`'s pure functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)