### PR TITLE
Replace button-definition tuples with ButtonDefinition NamedTuple

### DIFF
--- a/radioglobe/buttons.py
+++ b/radioglobe/buttons.py
@@ -1,8 +1,17 @@
 import asyncio
 import time
 import inspect
+from typing import Callable, NamedTuple, Optional
 
 import RPi.GPIO as GPIO  # type: ignore
+
+
+class ButtonDefinition(NamedTuple):
+    name: str
+    pin: int
+    short_cb: Optional[Callable] = None
+    long_cb: Optional[Callable] = None
+    press_cb: Optional[Callable] = None
 
 
 class AsyncButton:
@@ -69,15 +78,12 @@ class AsyncButtonManager:
         self.event_queue = asyncio.Queue()
 
         for definition in button_definitions:
-            if len(definition) == 5:
-                name, pin, short_cb, long_cb, press_cb = definition
-            else:
-                name, pin, short_cb, long_cb = definition
-                press_cb = None
-            btn = AsyncButton(name, pin, loop, long_press_threshold, press_cb)
+            btn = AsyncButton(
+                definition.name, definition.pin, loop, long_press_threshold, definition.press_cb
+            )
             self.buttons.append(btn)
-            setattr(btn, "short_cb", short_cb)
-            setattr(btn, "long_cb", long_cb)
+            setattr(btn, "short_cb", definition.short_cb)
+            setattr(btn, "long_cb", definition.long_cb)
 
     async def start(self):
         asyncio.create_task(self._poll_buttons())

--- a/radioglobe/main.py
+++ b/radioglobe/main.py
@@ -9,7 +9,7 @@ from typing import Optional
 import RPi.GPIO as GPIO  # type: ignore
 
 from radioglobe.audio_async import AudioPlayer
-from radioglobe.buttons import AsyncButtonManager
+from radioglobe.buttons import AsyncButtonManager, ButtonDefinition
 from radioglobe.constants import (
     COLOUR_BLUE, COLOUR_GREEN, COLOUR_RED,
     MODE_CITY, MODE_STATION,
@@ -407,10 +407,10 @@ class App:
         loop = asyncio.get_running_loop()
 
         button_definitions = [
-            ("Jog",    PIN_BTN_JOG,    self._handle_short_jog,    None,                    self._on_jog_press),
-            ("Top",    PIN_BTN_TOP,    self._handle_short_top,    self._handle_long_top,   self._on_sound_press),
-            ("Mid",    PIN_BTN_MID,    self._handle_short_mid,    self._handle_long_mid,   self._on_mid_press),
-            ("Bottom", PIN_BTN_BOTTOM, self._handle_short_bottom, self._handle_long_bottom, self._on_sound_press),
+            ButtonDefinition("Jog",    PIN_BTN_JOG,    self._handle_short_jog,    None,                     self._on_jog_press),
+            ButtonDefinition("Top",    PIN_BTN_TOP,    self._handle_short_top,    self._handle_long_top,   self._on_sound_press),
+            ButtonDefinition("Mid",    PIN_BTN_MID,    self._handle_short_mid,    self._handle_long_mid,   self._on_mid_press),
+            ButtonDefinition("Bottom", PIN_BTN_BOTTOM, self._handle_short_bottom, self._handle_long_bottom, self._on_sound_press),
         ]
 
         button_manager = AsyncButtonManager(button_definitions, loop)

--- a/tests/integration/button_test.py
+++ b/tests/integration/button_test.py
@@ -19,7 +19,7 @@ import pytest
 
 GPIO = pytest.importorskip("RPi.GPIO", reason="Requires Raspberry Pi hardware")
 
-from radioglobe.buttons import AsyncButtonManager
+from radioglobe.buttons import AsyncButtonManager, ButtonDefinition
 from radioglobe.radio_config import PIN_BTN_TOP, PIN_BTN_MID, PIN_BTN_BOTTOM
 
 BUTTONS = {
@@ -69,7 +69,7 @@ async def main():
     loop = asyncio.get_running_loop()
 
     button_definitions = [
-        (args.button, pin, on_short, on_long, on_press),
+        ButtonDefinition(args.button, pin, on_short, on_long, on_press),
     ]
 
     manager = AsyncButtonManager(


### PR DESCRIPTION
## Summary
- Adds `ButtonDefinition(name, pin, short_cb, long_cb=None, press_cb=None)` NamedTuple to `radioglobe/buttons.py`, replacing bare 4/5-element positional tuples in `main.py`'s and `button_test.py`'s `button_definitions` lists
- Removes the `len(definition) == 5` arity-branching hack in `AsyncButtonManager.__init__` — the NamedTuple's default `press_cb=None` handles the optional field uniformly

No behavior change — pure readability/maintainability fix (named fields instead of positional tuple ordering).

## Test plan
- [x] `python -m py_compile` on all changed files
- [x] `ruff check` (only pre-existing, unrelated `button_test.py` issues remain)
- [x] `python -m pytest tests/get_stations_by_city_test.py` — 4 passed
- [x] Deployed to radioglobe@radioglobe.local, restarted service, confirmed `active` on `v0.5.6-2-g4818309`, journal clean
- [x] Physically tested all four buttons (Jog, Top, Mid, Bottom — short and long press) on real hardware — confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)