### PR TITLE
Fix install.sh failures on Raspberry Pi OS Trixie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.5.8] - 2026-07-27
+### Fixed
+- `install.sh` failed on Raspberry Pi OS Trixie: the bluetooth `rfkill`
+  check used the bare command, but the `radioglobe` user's non-interactive
+  `PATH` excludes `/usr/sbin` on Trixie, causing "command not found"; now
+  run via `sudo`, whose `secure_path` includes it.
+- Added `swig` and `liblgpio-dev` to the apt dependency list — building the
+  `lgpio` Python wheel needs `swig`, and linking it needs `liblgpio-dev`
+  (only `liblgpio1`, the runtime lib, is pulled in transitively on Trixie).
+- `install.sh` crashed copying a missing `VERSION` file even though it
+  already had a fallback to report `"unknown"` for display; now writes the
+  resolved version string instead of copying the file.
+- `install.sh` now falls back to `git describe --tags --always --dirty`
+  for `VERSION` when run from a real git clone on the target host (no
+  `VERSION` file, but a real `.git` dir), instead of always reporting
+  `"unknown"` in that case.
+
+Physically tested end to end on real RadioGlobe hardware (Debian 13/Trixie)
+after each fix; confirmed `install.sh` completes cleanly and
+`/opt/radioglobe/VERSION` / the rendered `radioglobe.service` unit show the
+correct resolved version.
+
 ## [0.5.7] - 2026-07-27
 ### Changed
 - Replaced positional button-definition tuples with a `ButtonDefinition`

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,14 @@ SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "🚀 Installing RadioGlobe..."
 
 # -----------------------------
-# Version (injected from dev machine)
+# Version: prefer VERSION injected by `make deploy` from the dev
+# machine; fall back to `git describe` when running from a real
+# clone on the target host (e.g. installed directly via git clone).
 # -----------------------------
 if [[ -f "$SRC_DIR/VERSION" ]]; then
     VERSION=$(cat "$SRC_DIR/VERSION")
+elif [[ -d "$SRC_DIR/.git" ]]; then
+    VERSION=$(git -C "$SRC_DIR" describe --tags --always --dirty 2>/dev/null || echo "unknown")
 else
     VERSION="unknown"
 fi

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,9 @@ sudo apt install -y \
     python3-dev \
     pulseaudio-module-bluetooth \
     rfkill \
-    jq
+    jq \
+    swig \
+    liblgpio-dev
 
 # -----------------------------
 # Rotary encoder dtoverlay (idempotent)
@@ -49,7 +51,7 @@ fi
 # systemd-rfkill saves this state on change and restores it on
 # boot, so unblocking once here keeps it enabled across reboots.
 # -----------------------------
-if rfkill list bluetooth | grep -q "Soft blocked: yes"; then
+if sudo rfkill list bluetooth | grep -q "Soft blocked: yes"; then
     echo "📶 Unblocking Bluetooth radio..."
     sudo rfkill unblock bluetooth
 fi
@@ -85,7 +87,7 @@ sudo cp -r "$SRC_DIR/radioglobe" "$RADIOGLOBE_DIR/"
 # Stations + version
 sudo mkdir -p "$RADIOGLOBE_DIR/stations"
 sudo cp "$SRC_DIR/stations/stations.json" "$RADIOGLOBE_DIR/stations/"
-sudo cp "$SRC_DIR/VERSION" "$RADIOGLOBE_DIR/VERSION"
+echo "$VERSION" | sudo tee "$RADIOGLOBE_DIR/VERSION" > /dev/null
 
 sudo chown -R $RADIOGLOBE_USER:$RADIOGLOBE_USER $RADIOGLOBE_DIR
 


### PR DESCRIPTION
## Summary
- Add `swig` and `liblgpio-dev` to the apt dependency list — building the `lgpio` Python wheel needs `swig`, and linking it needs `liblgpio-dev` (only `liblgpio1`, the runtime lib, is pulled in transitively on Trixie).
- Run the bluetooth `rfkill` check via `sudo` — on Trixie the `radioglobe` user's non-interactive `PATH` excludes `/usr/sbin`, where `rfkill` lives, causing "command not found"; `sudo`'s `secure_path` includes it.
- Write the resolved `VERSION` string instead of copying the `VERSION` file, which crashed the script whenever the file was absent even though the earlier fallback to `"unknown"` suggested that case was handled.
- Fall back to `git describe --tags --always --dirty` for `VERSION` when running from a real git clone on the target host (no `VERSION` file, but a real `.git` dir) instead of silently reporting `"unknown"`.

## Test plan
- [x] Ran `install.sh` on real RadioGlobe hardware (Debian 13/Trixie) end to end after each fix; confirmed it completes cleanly and enables the systemd user service.
- [x] Verified `/opt/radioglobe/VERSION` and the rendered `radioglobe.service` unit correctly show the resolved version (`v0.5.7-dirty`) instead of `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)