### PR TITLE
Fix shutdown: grant radioglobe passwordless poweroff via sudoers.d

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,23 @@ if sudo rfkill list bluetooth | grep -q "Soft blocked: yes"; then
 fi
 
 # -----------------------------
+# Allow passwordless poweroff (idempotent)
+# The mid-button long-press shutdown handler runs `sudo poweroff`
+# from radioglobe.service, which has no TTY to answer a password
+# prompt. Some images grant the default user blanket NOPASSWD sudo;
+# scope it to just poweroff here instead of relying on that.
+# -----------------------------
+SUDOERS_FILE=/etc/sudoers.d/radioglobe-poweroff
+SUDOERS_LINE="$RADIOGLOBE_USER ALL=(root) NOPASSWD: /usr/sbin/poweroff"
+if [[ ! -f "$SUDOERS_FILE" ]] || ! grep -qxF "$SUDOERS_LINE" "$SUDOERS_FILE"; then
+    echo "🔑 Granting passwordless poweroff to $RADIOGLOBE_USER..."
+    echo "$SUDOERS_LINE" | sudo tee "$SUDOERS_FILE.tmp" > /dev/null
+    sudo visudo -c -f "$SUDOERS_FILE.tmp" > /dev/null
+    sudo chmod 0440 "$SUDOERS_FILE.tmp"
+    sudo mv "$SUDOERS_FILE.tmp" "$SUDOERS_FILE"
+fi
+
+# -----------------------------
 # Prepare install directory
 # -----------------------------
 echo "📁 Preparing install dir..."


### PR DESCRIPTION
## Summary
- Shutdown (Mid button long-press → `subprocess.run(["sudo", "poweroff"])` in `main.py`) had stopped working on real hardware: `radioglobe.service` runs with no TTY, so `sudo` has no way to prompt for a password, and no NOPASSWD rule existed for the `radioglobe` user.
- `install.sh` now installs a scoped `/etc/sudoers.d/radioglobe-poweroff` drop-in — `NOPASSWD` for `/usr/sbin/poweroff` only, not blanket sudo — validated with `visudo -c` before being put in place. Idempotent, matches the style of the existing rfkill-unblock step.

## Test plan
- [x] Ran `install.sh` on real RadioGlobe hardware; confirmed the new step logs "Granting passwordless poweroff to radioglobe..." and creates `/etc/sudoers.d/radioglobe-poweroff` (mode `0440`, owned by root).
- [x] Verified with `sudo -n -l` that it now lists `(root) NOPASSWD: /usr/sbin/poweroff` for the `radioglobe` user.
- [ ] Did not trigger an actual `poweroff` during verification, to avoid requiring a physical power-cycle of the device — the sudo authorization proof above stands in for a full end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)