### PR TITLE
Exclude local dev artifacts from make deploy's rsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ deploy: build
 		--exclude ".git" \
 		--exclude "__pycache__" \
 		--exclude "*.pyc" \
+		--exclude ".venv" \
+		--exclude ".pytest_cache" \
+		--exclude ".ruff_cache" \
+		--exclude ".claude" \
+		--exclude ".python-version" \
+		--exclude ".lgd-nfy0" \
 		./ $(REMOTE):$(REMOTE_DIR)/
 
 # -----------------------------


### PR DESCRIPTION
## Summary
- `make deploy`'s rsync only excluded `.git`, `__pycache__`, and `*.pyc`, so it shipped the entire local dev environment to the device's `~/RadioGlobe` staging checkout: the x86_64 `.venv` (wrong architecture, irrelevant — the device has its own venv under `/opt/radioglobe`), `.pytest_cache`, `.ruff_cache`, `.claude` (local Claude Code settings), `.python-version`, and `.lgd-nfy0`.
- Found when running `make deploy` for the first time this session dumped all of the above onto the device. Cleaned up the already-deployed copies by hand on the device; this PR stops it recurring by adding the missing excludes.

## Test plan
- [x] Re-ran `make deploy` on real hardware after the fix — confirmed only `Makefile` and `VERSION` transferred, no stray dev artifacts.
- [x] Followed with `make update` + a service restart; `radioglobe.service` came up active on the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)