### PR TITLE
Add liquidcrystal-i2c git dependency to pyproject.toml

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,7 @@ echo "📦 Installing Python dependencies..."
 sudo -u $RADIOGLOBE_USER \
     $RADIOGLOBE_DIR/venv/bin/python -m pip install --upgrade pip setuptools wheel
 
+
 # Install the project into the venv (pyproject.toml points to src/).
 # Prefer a built wheel in $SRC_DIR/dist if present (faster, reproducible), otherwise install from source.
 if [ -d "$SRC_DIR/dist" ] && ls "$SRC_DIR/dist/radioglobe-"*.whl >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "rpi-lgpio>=0.6",
     "smbus>=1.1.post2",
     "spidev>=3.7",
+    "liquidcrystal-i2c @ git+https://github.com/pl31/python-liquidcrystal_i2c.git@e26e4d22f039e9a2c04580dda072e8ca9693d1bb",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Ensures pip install . installs the I2C LCD driver on device installs.

Updates README to use the development repo and explicit latest-version tag checkout instructions (e.g. v0.6.0).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>