### PR TITLE
Small cleanup pass on display.py

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -543,7 +543,7 @@ Drives a 20×4 I2C character LCD at address 0x27 on bus 1, using the `liquidcrys
 
 - Internally maintains a 4-line text buffer and an `asyncio.Event` (`changed`). When `update()` or `message()` is called, the buffer is updated and the event is set.
 - `_display_loop()` is an asyncio Task that waits for the event, writes all 4 lines to the LCD, and sleeps 100ms. This coalesces rapid updates — important because I2C is slow.
-- All strings are truncated to `DISPLAY_COLUMNS` characters before `center()` is applied, so overlong city or station names never overflow the hardware line buffer.
+- All 4 buffer lines (coords, location, volume bar, station) are truncated to `_DISPLAY_COLUMNS` characters before `center()` is applied, so overlong city or station names never overflow the hardware line buffer.
 - `show_station(coords, city, station_name)` and `show_status(status, coords=None)` wrap `update()`'s 5-argument shape for the two call patterns `App` actually uses (added in the decoupling refactor so `App` no longer needs to know `update()`'s full signature or repeat its `volume=0, arrows=False` boilerplate). The one place `App` still calls `update()` directly is the volume overlay in `_show_volume_briefly()`, which needs the `volume` argument `show_station()` hardcodes to 0.
 
 **Display layout when playing:**
@@ -818,7 +818,7 @@ constants in the module that owns that hardware, and are not re-exported.
 Where another module genuinely needs the value, it imports it directly from
 the owning module by name (e.g. `positional_encoders.py` imports
 `_ENCODER_RESOLUTION` from `database.py`, §4.5). This mirrors `display.py`'s
-pre-existing `DISPLAY_COLUMNS`/`DISPLAY_ROWS` pattern. `buttons.py` goes a
+pre-existing `_DISPLAY_COLUMNS`/`_DISPLAY_ROWS` pattern. `buttons.py` goes a
 step further: its `_PIN_BTN_*` pin constants have zero consumers outside the
 module — `main.py` and the integration test scripts consume the higher-level
 `JOG_BUTTON`/`TOP_BUTTON`/`MID_BUTTON`/`BOTTOM_BUTTON` constants instead
@@ -873,7 +873,7 @@ imports it.
 | `_PIN_BTN_JOG` / `_PIN_BTN_TOP` / `_PIN_BTN_MID` / `_PIN_BTN_BOTTOM` | 27 / 5 / 6 / 12 | `buttons.py` — never imported elsewhere; exposed to `main.py` only indirectly via the `JOG_BUTTON`/`TOP_BUTTON`/`MID_BUTTON`/`BOTTOM_BUTTON` `ButtonDefinition` constants (§4.7), which pair each pin with its fixed board role |
 | `_PIN_LED_R` / `_PIN_LED_G` / `_PIN_LED_B` | 22 / 23 / 24 | `rgb_led.py` — `RGBLed.__init__` defaults; never needed outside this module (`main.py` constructs `RGBLed()` with no args) |
 | `COLOUR_RED` / `COLOUR_GREEN` / `COLOUR_BLUE` / `COLOUR_WHITE` / `COLOUR_OFF` | `"red"` / `"green"` / `"blue"` / `"white"` / `"off"` | `rgb_led.py` (§4.10) — public (not underscore-prefixed, unlike this table's other rows), since `main.py` and integration test scripts need them; moved from `constants.py` to eliminate a duplicate definition of the same vocabulary in `RGBLed.COLOURS` — passes the hardware-intrinsic test above (a different LED module could support a different colour set) |
-| `_I2C_LCD_ADDR` | `0x27` | `display.py`, alongside the pre-existing `DISPLAY_I2C_PORT`/`DISPLAY_COLUMNS`/`DISPLAY_ROWS` |
+| `_I2C_LCD_ADDR` | `0x27` | `display.py`, alongside the pre-existing `_DISPLAY_I2C_PORT`/`_DISPLAY_COLUMNS`/`_DISPLAY_ROWS` |
 | SPI poll interval | 50ms (`asyncio.sleep(0.05)`) | `positional_encoders.py` — `run_encoder()`; hardcoded. Raised from an original 200ms — see `docs/KERNEL_ROTARY_ENCODER_INVESTIGATION.md` |
 | SPI clock speed | `max_speed_hz = 1000000` | `positional_encoders.py` — `read_spi()`; hardcoded. Raised from an original 5000 Hz to the Bourns EMS22A50-D28-LT6 datasheet maximum |
 | `UNLATCH_CONFIRM_THRESHOLD` | 2 | `positional_encoders.py` class constant — consecutive out-of-band readings required before unlatching, added to filter sensor noise at the faster poll rate |

--- a/src/radioglobe/display.py
+++ b/src/radioglobe/display.py
@@ -5,21 +5,17 @@ import liquidcrystal_i2c  # type: ignore
 from .coordinates import Coordinate
 
 _I2C_LCD_ADDR = 0x27
-DISPLAY_I2C_PORT = 1
-DISPLAY_COLUMNS = 20
-DISPLAY_ROWS = 4
-
-# Configure logging
-# logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+_DISPLAY_I2C_PORT = 1
+_DISPLAY_COLUMNS = 20
+_DISPLAY_ROWS = 4
 
 
 class Display:
     def __init__(self):
         self.lcd = liquidcrystal_i2c.LiquidCrystal_I2C(
-            _I2C_LCD_ADDR, DISPLAY_I2C_PORT, numlines=DISPLAY_ROWS
+            _I2C_LCD_ADDR, _DISPLAY_I2C_PORT, numlines=_DISPLAY_ROWS
         )
-        self.buffer = ["" for _ in range(DISPLAY_ROWS)]
+        self.buffer = ["" for _ in range(_DISPLAY_ROWS)]
         self.changed = asyncio.Event()
         self.running = True
         self._task = None
@@ -43,7 +39,7 @@ class Display:
         while self.running:
             await self.changed.wait()
             try:
-                for line_num in range(DISPLAY_ROWS):
+                for line_num in range(_DISPLAY_ROWS):
                     self.lcd.printline(line_num, self.buffer[line_num])
             except Exception as e:
                 logging.error(f"Display write failed: {e}")
@@ -51,10 +47,10 @@ class Display:
             await asyncio.sleep(0.1)
 
     def message(self, line_1="", line_2="", line_3="", line_4=""):
-        self.buffer[0] = line_1[:DISPLAY_COLUMNS].center(DISPLAY_COLUMNS)
-        self.buffer[1] = line_2[:DISPLAY_COLUMNS].center(DISPLAY_COLUMNS)
-        self.buffer[2] = line_3[:DISPLAY_COLUMNS].center(DISPLAY_COLUMNS)
-        self.buffer[3] = line_4[:DISPLAY_COLUMNS].center(DISPLAY_COLUMNS)
+        self.buffer[0] = line_1[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
+        self.buffer[1] = line_2[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
+        self.buffer[2] = line_3[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
+        self.buffer[3] = line_4[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.changed.set()
         logging.info(f"Message set: {[line_1, line_2, line_3, line_4]}")
 
@@ -67,25 +63,20 @@ class Display:
         self.update(coords or Coordinate(0, 0), status, volume=0, station="", arrows=False)
 
     def update(self, coords: Coordinate, location: str, volume: int, station: str, arrows: bool):
-        self.buffer[0] = str(coords).center(DISPLAY_COLUMNS)
-        self.buffer[1] = location[:DISPLAY_COLUMNS].center(DISPLAY_COLUMNS)
+        self.buffer[0] = str(coords)[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
+        self.buffer[1] = location[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
 
         # Volume bar
-        if not volume:
-            volume = 0
-        bar_length = (volume * DISPLAY_COLUMNS) // 100
-        self.buffer[2] = "-" * bar_length + " " * (DISPLAY_COLUMNS - bar_length)
+        bar_length = (volume * _DISPLAY_COLUMNS) // 100
+        self.buffer[2] = "-" * bar_length + " " * (_DISPLAY_COLUMNS - bar_length)
 
         if arrows and station:
-            station = str(station)[: DISPLAY_COLUMNS - 4]
-            padding = DISPLAY_COLUMNS - 4 - len(station)
+            station = str(station)[: _DISPLAY_COLUMNS - 4]
+            padding = _DISPLAY_COLUMNS - 4 - len(station)
             station = " " * (padding // 2) + station + " " * (padding - padding // 2)
             station = "< " + station + " >"
         else:
-            station = str(station)[:DISPLAY_COLUMNS]
-        self.buffer[3] = station.center(DISPLAY_COLUMNS)
+            station = str(station)[:_DISPLAY_COLUMNS]
+        self.buffer[3] = station.center(_DISPLAY_COLUMNS)
 
         self.changed.set()
-        # logging.debug(
-        #     f"Display updated: coords={coords}, location='{location}', volume={volume}, station='{station}', arrows={arrows}"
-        # )


### PR DESCRIPTION
## Summary

Reviewed `display.py` against the constant-ownership heuristic from the previous fix (`ARCHITECTURE.md` §8) — it already passes cleanly, no `buttons.py`/`dial.py`/`rgb_led.py`-style ownership violation. Three smaller things found and fixed:

- Renamed `DISPLAY_COLUMNS`/`DISPLAY_ROWS`/`DISPLAY_I2C_PORT` → `_DISPLAY_COLUMNS`/`_DISPLAY_ROWS`/`_DISPLAY_I2C_PORT`, matching `_I2C_LCD_ADDR`'s privacy in the same file (all have zero consumers outside `display.py`).
- `update()`'s coords line skipped the `[:_DISPLAY_COLUMNS]` truncation guard that `location`/`station` get, despite `ARCHITECTURE.md` claiming all four buffer lines were truncated. Currently latent (`Coordinate.__str__()` always produces <20 chars) but the code didn't actually guarantee it — added the guard.
- Removed dead code: a fully commented-out logger-setup block, a redundant `if not volume: volume = 0` no-op (`0 * columns // 100 == 0` already), and a commented-out trailing debug log.
- Updated `ARCHITECTURE.md` §4.8 and §8 to match the renamed constants.

## Test plan
- [x] Full unit suite passes (`PYTHONPATH=src python -m pytest tests/ -q` — 71 passed)
- [x] `ruff check` clean
- [x] Grep confirms no remaining un-prefixed `DISPLAY_COLUMNS`/`DISPLAY_ROWS`/`DISPLAY_I2C_PORT` anywhere in `src/`/`tests/`/`ARCHITECTURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)