### PR TITLE
Adopt kernel gpio-led driver for the RGB status LED

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@ The Raspberry Pi 4B runs Raspberry Pi OS Bookworm Lite. Audio plays through VLC 
 | Mid button (calibrate / shutdown) | GPIO (kernel `gpio-keys` driver + evdev) | Pin 6 | `buttons.py` |
 | Bottom button (volume down) | GPIO (kernel `gpio-keys` driver + evdev) | Pin 12 | `buttons.py` |
 | 20×4 character LCD | I2C | Bus 1, address 0x27 | `display.py` |
-| RGB status LED | GPIO | R=22, G=23, B=24 | `rgb_led.py` |
+| RGB status LED | GPIO (kernel `gpio-led`/`leds-gpio` driver + sysfs) | R=22, G=23, B=24 | `rgb_led.py` |
 | Audio output | VLC / PulseAudio | 3.5mm / Bluetooth | `audio_async.py` |
 
 ### Button Operations
@@ -146,7 +146,7 @@ graph TD
     main --> dial["dial.py\nkernel rotary-encoder + evdev"]
     main --> buttons["buttons.py\nkernel gpio-keys + evdev"]
     main --> display["display.py\nI2C LCD display"]
-    main --> led["rgb_led.py\nGPIO LED"]
+    main --> led["rgb_led.py\nkernel gpio-led + sysfs"]
     main --> audio["audio_async.py\nVLC audio player"]
     main --> nav["navigation.py\n(Navigator)"]
     main --> database["database.py\nPure functions"]
@@ -162,7 +162,7 @@ graph TD
     display --> i2c[("liquidcrystal_i2c")]
     dial --> input[("evdev /dev/input/eventN")]
     buttons --> input
-    led --> gpio[("lgpio / RPi.GPIO")]
+    led --> sysfs[("sysfs /sys/class/leds/*")]
 ```
 
 `App` still imports `get_stations_by_city` (`database.py`) directly — used
@@ -253,9 +253,10 @@ a named `Navigator` method.
 A small dataclass holding the app's mutable station/city selection state,
 owned by `Navigator` (§4.3) rather than `App` directly. Split out of
 `main.py` into its own module specifically so it has no hardware
-dependency: `main.py` imports `RPi.GPIO` at module level and can't be
-imported off a Raspberry Pi at all, so anything meant to be unit-testable
-has to live somewhere that doesn't transitively pull that in.
+dependency: `main.py` transitively imports `evdev` at module level (via
+`buttons.py`, §4.14) and can't be imported off a Raspberry Pi at all
+without stubbing it, so anything meant to be unit-testable has to live
+somewhere that doesn't transitively pull that in.
 
 | Field | Type | Meaning |
 |---|---|---|
@@ -597,15 +598,53 @@ class AudioPlayer:
 
 ### 4.10 `rgb_led.py` — Status LED
 
-Three GPIO output pins (R=22, G=23, B=24) with simple on/off control (no PWM).
+Three LED channels (R=22, G=23, B=24), each read via the kernel's
+`gpio-led`/`leds-gpio` driver + sysfs — the same kernel-driver approach
+`dial.py` (§4.6) and `buttons.py` (§4.7) already use — rather than
+`RPi.GPIO.output()`. Migrated because the experiment
+(`tests/integration/rgb_led_gpio_led_test.py`, kept as a standalone
+zero-`radioglobe`-dependency diagnostic, same role
+`encoder_hardware_test.py`/`jog_gpio_keys_test.py` play for the dial/buttons)
+showed correct colours with no flicker on real hardware. `rgb_led.py` was
+the *last* module using `RPi.GPIO`; migrating it means `import RPi.GPIO`
+has zero remaining consumers in `src/`, so `lgpio`/`rpi-lgpio` (and the
+`swig`/`liblgpio-dev` apt packages needed to build them) were removed
+entirely rather than just from this one module (§8).
 
-`RGBLed.flash(colour, duration)` is an async method, always spawned with `asyncio.create_task()` rather than awaited. It:
+Each channel is controlled by writing `"1"`/`"0"` to
+`/sys/class/leds/<label>/brightness`, where `<label>` comes from
+`install.sh`'s `dtoverlay=gpio-led,gpio=<pin>,label=<label>` line — unlike
+`gpio-key`, `gpio-led`'s `label=` was confirmed on-device to reliably set
+the sysfs device name, so (unlike `buttons.py`) no keycode-style
+disambiguation workaround is needed; `RGBLed._resolve(label)` just builds
+the path directly. `_resolve()` also does a one-time test write during
+`__init__`, converting a bare `PermissionError` into a `RuntimeError` that
+names the udev rule to check — see the permissions paragraph below, the
+one part of this migration the dial/button ones didn't need.
+
+`max_brightness` is `1` for these LEDs (binary on/off only, confirmed
+on-device) — identical to what `RPi.GPIO.output(HIGH/LOW)` already gave,
+so this migration changes nothing about brightness/dimming capability.
+
+`RGBLed.flash(colour, duration)` is unchanged in shape — still an async
+method, always spawned with `asyncio.create_task()` rather than awaited. It:
 1. Checks its own `self._running` Event to prevent overlapping flashes (a no-op if a flash is already in progress)
 2. Sets the event, turns the LED on
 3. Sleeps for `duration` seconds
 4. Turns the LED off and clears the event
 
-This used to be a standalone coroutine (`led_task(led, led_running, colour, duration)`) that every call site in `main.py` had to pass a shared `asyncio.Event` into by reference — folded into `RGBLed` itself in the decoupling refactor so `App` only needs to know `self.led.flash(colour, duration)` exists, not that it needs a co-owned `Event`. `RGBLed.__init__` also calls `GPIO.setmode(GPIO.BCM)` itself, for the same self-sufficiency reason as `AsyncButtonManager` — see §4.7. `RGBLed.stop()` mirrors this on teardown: it turns the LED off, then calls `GPIO.cleanup(list(self.pins.values()))` to release only its own 3 pins, rather than relying on a process-wide `GPIO.cleanup()` call in `main.py`.
+`RGBLed.stop()` now just calls `self.off()` — no `GPIO.cleanup()`
+equivalent, since Python never claims these pins at all any more; the
+kernel driver does, exactly like `dial.py`/`buttons.py`. `__init__` no
+longer calls `GPIO.setmode()` either, for the same reason.
+
+**Permissions — the one gap this migration has that the dial/button ones
+didn't:** `/sys/class/leds/*/brightness` is `root:root` mode `644` by
+default (confirmed on-device, unlike `/dev/input/*` which is readable via
+the `input` group). `install.sh` installs a udev rule
+(`/etc/udev/rules.d/99-radioglobe-leds.rules`) granting the `radioglobe`
+user's existing `gpio` group write access, and reloads/retriggers udev so
+a re-run fixes permissions on LEDs that already exist from a prior boot.
 
 `COLOUR_RED`/`COLOUR_GREEN`/`COLOUR_BLUE`/`COLOUR_WHITE`/`COLOUR_OFF` are
 public constants owned here (moved from `constants.py`), and `RGBLed.COLOURS`
@@ -692,7 +731,7 @@ platform. Three files, all new, none of which required changing `dial.py`,
   Pi-backed `(dial, audio_player, encoders, display, led)` tuple. The concrete
   hardware modules are imported inside its function body, not at module
   scope, so importing `radioglobe.hal` never pulls in `evdev`/`spidev`/
-  `RPi.GPIO`/`liquidcrystal_i2c`/`vlc` — only calling `build_hardware()` does.
+  `liquidcrystal_i2c`/`vlc` — only calling `build_hardware()` does.
 
 `App.__init__` (§4.1) takes these 5 hardware objects as required constructor
 parameters (typed against the Protocols above) instead of constructing them
@@ -712,17 +751,18 @@ real-class-plus-stub approach remains the way to test
 
 **Residual import gap:** `main.py` imports `create_button_manager`/
 `ButtonCallbacks` from `buttons.py` at module scope, and (since the
-`gpio-keys` migration, §4.7) `buttons.py` now imports `evdev` at module
-scope instead of `RPi.GPIO`. Separately, `main.py` also imports
-`COLOUR_RED`/`COLOUR_GREEN`/`COLOUR_BLUE` from `rgb_led.py`, which still
-imports `RPi.GPIO`. So `import radioglobe.main` (and therefore
-`radioglobe.cli`) requires **both** `evdev` and `RPi.GPIO` to be importable
-(real or stubbed), independent of this HAL. Any test importing
-`radioglobe.main` needs both stubs — see `tests/main_test.py`.
-`tests/buttons_test.py` only needs the `evdev` stub, since it imports
-`radioglobe.buttons` directly, not `radioglobe.main`/`radioglobe.rgb_led`.
-`radioglobe.hal` itself has no such requirement — it never imports
-`radioglobe.buttons`, `radioglobe.rgb_led`, or `radioglobe.main`.
+`gpio-keys` migration, §4.7) `buttons.py` imports `evdev` at module scope.
+So `import radioglobe.main` (and therefore `radioglobe.cli`) requires
+`evdev` to be importable (real or stubbed), independent of this HAL. Any
+test importing `radioglobe.main` needs the same
+`sys.modules.setdefault("evdev", MagicMock())` stub `tests/buttons_test.py`
+already uses — see `tests/main_test.py`. `radioglobe.hal` itself has no
+such requirement — it never imports `radioglobe.buttons` or `radioglobe.main`.
+
+This gap used to also include `RPi.GPIO`, via `main.py`'s import of
+`COLOUR_*` from `rgb_led.py`. Once `rgb_led.py` migrated to the kernel
+`gpio-led` driver too (§4.10), `RPi.GPIO` dropped out of this chain
+entirely — `main.py` now needs only `evdev`, not both.
 
 This is worth distinguishing from an earlier, *avoidable* version of this
 same gap: a pass once moved `_LED_FLASH_DIAL` (a pure UX duration, not a
@@ -904,7 +944,8 @@ imports it.
 | `_ENCODER_RESOLUTION` | 1024 | `database.py` — owned here (not `positional_encoders.py`) so the pure grid-math module stays hardware-free; `positional_encoders.py` imports it from `database.py` (§4.5) |
 | `_PIN_BTN_JOG` / `_PIN_BTN_TOP` / `_PIN_BTN_MID` / `_PIN_BTN_BOTTOM` | 27 / 5 / 6 / 12 | `buttons.py` — documentation only since the `gpio-keys` migration (§4.7); the kernel driver claims these pins directly via `install.sh`'s overlay lines, nothing in Python reads them |
 | `_KEYCODE_BTN_JOG` / `_KEYCODE_BTN_TOP` / `_KEYCODE_BTN_MID` / `_KEYCODE_BTN_BOTTOM` | `BTN_0`/`BTN_1`/`BTN_2`/`BTN_3` (256-259) | `buttons.py` — functionally load-bearing (§4.7): `AsyncButton._find_button_device()` matches evdev devices by keycode, since the `gpio-key` overlay's `label=` param doesn't reliably set the device name. `install.sh`'s overlay lines must use these same values |
-| `_PIN_LED_R` / `_PIN_LED_G` / `_PIN_LED_B` | 22 / 23 / 24 | `rgb_led.py` — `RGBLed.__init__` defaults; never needed outside this module (`main.py` constructs `RGBLed()` with no args) |
+| `_PIN_LED_R` / `_PIN_LED_G` / `_PIN_LED_B` | 22 / 23 / 24 | `rgb_led.py` — documentation only since the `gpio-led` migration (§4.10); the kernel driver claims these pins directly via `install.sh`'s overlay lines, nothing in Python reads them |
+| `_LED_LABEL_RED` / `_LED_LABEL_GREEN` / `_LED_LABEL_BLUE` | `"led-red"` / `"led-green"` / `"led-blue"` | `rgb_led.py` — functionally load-bearing (§4.10): `RGBLed._resolve()` builds `/sys/class/leds/<label>/brightness` directly from these, since `gpio-led`'s `label=` reliably sets the sysfs device name (unlike `gpio-key`'s). `install.sh`'s overlay lines must use these same values |
 | `COLOUR_RED` / `COLOUR_GREEN` / `COLOUR_BLUE` / `COLOUR_WHITE` / `COLOUR_OFF` | `"red"` / `"green"` / `"blue"` / `"white"` / `"off"` | `rgb_led.py` (§4.10) — public (not underscore-prefixed, unlike this table's other rows), since `main.py` and integration test scripts need them; moved from `constants.py` to eliminate a duplicate definition of the same vocabulary in `RGBLed.COLOURS` — passes the hardware-intrinsic test above (a different LED module could support a different colour set) |
 | `_I2C_LCD_ADDR` | `0x27` | `display.py`, alongside the pre-existing `_DISPLAY_I2C_PORT`/`_DISPLAY_COLUMNS`/`_DISPLAY_ROWS` |
 | SPI poll interval | 50ms (`asyncio.sleep(0.05)`) | `positional_encoders.py` — `run_encoder()`; hardcoded. Raised from an original 200ms — see `docs/KERNEL_ROTARY_ENCODER_INVESTIGATION.md` |
@@ -922,12 +963,20 @@ comment marking that line as the single source of truth for those two pins.
 
 ### Optional Pi-specific dependencies
 
-`evdev`, `lgpio`, `rpi-lgpio`, `smbus`, `spidev`, `liquidcrystal-i2c` and
-`python-vlc` live in `pyproject.toml`'s `[project.optional-dependencies]`
-`pi` group, not the base `dependencies` list — `pip install .[pi]` (or
-`install.sh`/`update.sh`, which already do this). The base package, `hal/`'s
-Protocols/fakes, and the unit test suite need none of them; only the six
-hardware modules that actually import these libraries do (§4.14).
+`evdev`, `smbus`, `spidev`, `liquidcrystal-i2c` and `python-vlc` live in
+`pyproject.toml`'s `[project.optional-dependencies]` `pi` group, not the
+base `dependencies` list — `pip install .[pi]` (or `install.sh`/`update.sh`,
+which already do this). The base package, `hal/`'s Protocols/fakes, and the
+unit test suite need none of them; only the hardware modules that actually
+import these libraries do (§4.14). `rgb_led.py` needs **none** of them —
+its `gpio-led` migration (§4.10) means it uses only `pathlib` (stdlib).
+
+`lgpio`/`rpi-lgpio` (which provided `RPi.GPIO`'s namespace on this kernel)
+were removed from the `pi` extra entirely once `rgb_led.py` migrated —
+`import RPi.GPIO` has zero remaining consumers anywhere in `src/`
+(`dial.py`/`buttons.py` use `evdev`, `rgb_led.py` uses sysfs). The apt
+packages that existed only to build `lgpio`'s bindings (`swig`,
+`liblgpio-dev`) were removed from `install.sh` for the same reason.
 
 ---
 
@@ -953,7 +1002,7 @@ uv run pytest
 | `hal/protocols_test.py` | `isinstance(FakeX(), XProtocol)` for all 6 fakes — a regression guard that fakes stay in sync with the Protocol shape |
 | `main_test.py` | `App`'s `_encoder_loop`/`_dial_loop`/`_monitor_stream`/`save_state`/`load_state` (§4.1, §4.14), driven end-to-end via HAL fakes with no real hardware — distinct from the hardware-only `tests/integration/main_test.py` |
 
-All follow the same style: plain `unittest.TestCase`/`IsolatedAsyncioTestCase`, in-memory fixture data, no mocking framework — the module structure introduced in the decoupling refactor made `AppState` and `Navigator` testable this way for the first time; before it, only `database.py` had real unit tests. `buttons_test.py` stubs `evdev` in `sys.modules` before importing `radioglobe.buttons`, since that module now imports evdev at module scope (§4.7's `gpio-keys` migration); `main_test.py` stubs both `evdev` and `RPi.GPIO`, since `radioglobe.main` transitively imports both `radioglobe.buttons` (evdev) and `radioglobe.rgb_led` (RPi.GPIO) (§4.14's residual import gap). `hal/fake_test.py` and `hal/protocols_test.py` need no such stub — `radioglobe.hal` never imports `radioglobe.buttons`, `radioglobe.rgb_led`, or `radioglobe.main`. None of the unit tests need the `pi` extra installed (§8); only `tests/integration/` does.
+All follow the same style: plain `unittest.TestCase`/`IsolatedAsyncioTestCase`, in-memory fixture data, no mocking framework — the module structure introduced in the decoupling refactor made `AppState` and `Navigator` testable this way for the first time; before it, only `database.py` had real unit tests. `buttons_test.py` and `main_test.py` both stub `evdev` in `sys.modules` before importing `radioglobe.buttons`/`radioglobe.main`, since `buttons.py` imports evdev at module scope (§4.7's `gpio-keys` migration) and `main.py` transitively imports it (§4.14's residual import gap). Neither needs an `RPi.GPIO` stub any more — `rgb_led.py`'s `gpio-led` migration (§4.10) removed the last consumer of it. `hal/fake_test.py` and `hal/protocols_test.py` need no such stub — `radioglobe.hal` never imports `radioglobe.buttons`, `radioglobe.rgb_led`, or `radioglobe.main`. None of the unit tests need the `pi` extra installed (§8); only `tests/integration/` does.
 
 **Hardware / integration scripts** live in `tests/integration/` and must be run directly on the Pi. See [tests/integration/README.md](tests/integration/README.md) for the full, maintained list, usage examples, and hardware setup notes — duplicating it here previously went stale (a `simulation_test.py` that never existed lingered in this table for a while; three scripts also silently broke when `led_task` was folded into `RGBLed.flash()`, since nothing exercises them automatically). Highlights:
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Audio code is now in `radioglobe/streaming/python_vlc_streaming.py` which uses p
 
 To take advantage of pulseaudio it is important to have a logged in user and RadioGlobe must be started as the default user. This will start pulseaudio in a secure way and allow automatic detection of your output devices.
 
-Audio has changed across the last Debian versions; both `Bookworm` and `Trixie` have been tested. `Trixie` needs a couple of extra apt packages (`swig`, `liblgpio-dev`) to build the GPIO Python bindings — `install.sh` installs these automatically.
+Audio has changed across the last Debian versions; both `Bookworm` and `Trixie` have been tested.
 
 Note that radio stations change their URLs all the time so a URL may be out-of-date. You can update this by editing the `stations.json` file. Save a copy first! Some stations go `off-line` in their night time, depending on your timezone. Try back later or you can remove them from `stations.json`.
 
@@ -259,14 +259,16 @@ source .venv/bin/activate
 ```
 uv init --no-workspace
 ```
-6. Add dependencies. `python-vlc`, `lgpio`/`rpi-lgpio`, `liquidcrystal-i2c`, `spidev`
-   and `smbus` are Pi-hardware-only and belong in the `pi` extra (see
+6. Add dependencies. `python-vlc`, `liquidcrystal-i2c`, `spidev` and `smbus`
+   are Pi-hardware-only and belong in the `pi` extra (see
    `pyproject.toml`'s `[project.optional-dependencies]`), not the base
-   dependencies — the core package and unit test suite don't need them:
+   dependencies — the core package and unit test suite don't need them.
+   `lgpio`/`rpi-lgpio` (which provided `RPi.GPIO`) are no longer needed at
+   all — `dial.py`/`buttons.py`/`rgb_led.py` are all kernel-driven
+   (evdev/sysfs) rather than talking to GPIO pins directly:
 ```
 uv add --dev pytest
 uv add --optional pi python-vlc
-uv add --optional pi lgpio rpi-lgpio
 uv add --optional pi "liquidcrystal-i2c @ git+https://github.com/pl31/python-liquidcrystal_i2c.git"
 uv add --optional pi spidev smbus
 ```

--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,7 @@ sudo apt install -y \
     python3-dev \
     pulseaudio-module-bluetooth \
     rfkill \
-    jq \
-    swig \
-    liblgpio-dev
+    jq
 
 # -----------------------------
 # Rotary encoder dtoverlay (idempotent)
@@ -78,6 +76,49 @@ for line in "${BUTTON_OVERLAY_LINES[@]}"; do
         echo "$line" | sudo tee -a "$CONFIG_TXT" > /dev/null
     fi
 done
+
+# -----------------------------
+# RGB LED dtoverlays (idempotent)
+# -----------------------------
+# The RGB status LED is driven via the kernel gpio-led (leds-gpio) driver
+# instead of RPi.GPIO. label= values must match rgb_led.py's
+# _LED_LABEL_RED/_GREEN/_BLUE constants exactly - unlike gpio-key, gpio-led's
+# label= was confirmed on-device to reliably set the sysfs device name
+# (/sys/class/leds/<label>/brightness), so no keycode-style workaround is
+# needed here.
+LED_OVERLAY_LINES=(
+    "dtoverlay=gpio-led,gpio=22,label=led-red"
+    "dtoverlay=gpio-led,gpio=23,label=led-green"
+    "dtoverlay=gpio-led,gpio=24,label=led-blue"
+)
+for line in "${LED_OVERLAY_LINES[@]}"; do
+    if ! grep -qxF "$line" "$CONFIG_TXT"; then
+        echo "⚙️ Adding LED dtoverlay to $CONFIG_TXT: $line"
+        echo "$line" | sudo tee -a "$CONFIG_TXT" > /dev/null
+    fi
+done
+
+# -----------------------------
+# LED sysfs udev rule (idempotent)
+# -----------------------------
+# /sys/class/leds/*/brightness is root:root mode 644 by default - unlike
+# /dev/input/* (readable via the `input` group), nothing grants a
+# non-root user write access. $RADIOGLOBE_USER is already in the `gpio`
+# group (used for GPIO character device access), so reuse it here rather
+# than inventing a new group.
+UDEV_RULES_FILE=/etc/udev/rules.d/99-radioglobe-leds.rules
+UDEV_RULES_CONTENT='SUBSYSTEM=="leds", KERNEL=="led-red", RUN+="/bin/chgrp gpio /sys%p/brightness", RUN+="/bin/chmod g+w /sys%p/brightness"
+SUBSYSTEM=="leds", KERNEL=="led-green", RUN+="/bin/chgrp gpio /sys%p/brightness", RUN+="/bin/chmod g+w /sys%p/brightness"
+SUBSYSTEM=="leds", KERNEL=="led-blue", RUN+="/bin/chgrp gpio /sys%p/brightness", RUN+="/bin/chmod g+w /sys%p/brightness"'
+if [[ ! -f "$UDEV_RULES_FILE" ]] || ! diff -q <(echo "$UDEV_RULES_CONTENT") "$UDEV_RULES_FILE" > /dev/null 2>&1; then
+    echo "🔑 Installing udev rule for LED sysfs access..."
+    echo "$UDEV_RULES_CONTENT" | sudo tee "$UDEV_RULES_FILE" > /dev/null
+    sudo udevadm control --reload-rules
+    # Re-applies to LEDs that already exist from a prior boot (e.g. re-running
+    # install.sh after upgrading) - a no-op if the overlay hasn't loaded yet,
+    # which still needs the reboot below regardless.
+    sudo udevadm trigger --subsystem-match=leds || true
+fi
 
 # -----------------------------
 # Ensure Bluetooth radio isn't soft-blocked (idempotent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,15 @@ dependencies = [
 
 [project.optional-dependencies]
 # Hardware-backed modules (dial.py, positional_encoders.py, buttons.py,
-# rgb_led.py, display.py, audio_async.py) need these; the core package,
+# display.py, audio_async.py) need these; the core package,
 # radioglobe.hal's Protocols/fakes, and the unit test suite do not.
-# Install with `pip install .[pi]` (or `uv sync --extra pi`) on the device.
+# rgb_led.py needs none of these - it's kernel-driven via sysfs
+# (dtoverlay=gpio-led) using only the stdlib, same as dial.py/buttons.py's
+# evdev-based kernel drivers. Install with `pip install .[pi]`
+# (or `uv sync --extra pi`) on the device.
 pi = [
     "evdev>=1.7.0",
-    "lgpio>=0.2.2.0",
     "python-vlc>=3.0.21203",
-    "rpi-lgpio>=0.6",
     "smbus>=1.1.post2",
     "spidev>=3.7",
     "liquidcrystal-i2c @ git+https://github.com/pl31/python-liquidcrystal_i2c.git@e26e4d22f039e9a2c04580dda072e8ca9693d1bb",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-# evdev, lgpio, liquidcrystal-i2c, python-vlc, rpi-lgpio, smbus and spidev
-# correspond to pyproject.toml's `pi` extra (pip install .[pi]).
+# evdev, liquidcrystal-i2c, python-vlc, smbus and spidev correspond to
+# pyproject.toml's `pi` extra (pip install .[pi]). lgpio/rpi-lgpio were
+# removed once rgb_led.py's gpio-led migration made them unused - the
+# dial/buttons/rgb_led are now all kernel-driven (evdev/sysfs), not RPi.GPIO.
 evdev==1.9.3
 iniconfig==2.1.0
-lgpio==0.2.2.0
 liquidcrystal-i2c @ git+https://github.com/pl31/python-liquidcrystal_i2c.git@e26e4d22f039e9a2c04580dda072e8ca9693d1bb
 packaging==25.0
 pluggy==1.6.0
 pygments==2.19.1
 pytest==8.4.0
 python-vlc==3.0.21203
-rpi-lgpio==0.6
 smbus==1.1.post2
 spidev==3.7

--- a/src/radioglobe/rgb_led.py
+++ b/src/radioglobe/rgb_led.py
@@ -1,11 +1,25 @@
 import asyncio
 import logging
-import RPi.GPIO as GPIO  # type: ignore
+from pathlib import Path
 
-# GPIO pin assignments (BCM numbering)
+_LED_SYSFS_DIR = Path("/sys/class/leds")
+
+# GPIO pin assignments (BCM numbering) - documentation only. The kernel
+# gpio-led driver claims these pins directly via install.sh's
+# dtoverlay=gpio-led,... lines; nothing in this module reads them.
 _PIN_LED_R = 22
 _PIN_LED_G = 23
 _PIN_LED_B = 24
+
+# gpio-led overlay labels - functionally load-bearing: install.sh's
+# dtoverlay=gpio-led,...,label=<name> lines must use these same values,
+# since each becomes the sysfs device name directly
+# (/sys/class/leds/<label>/brightness). Unlike gpio-key, gpio-led's
+# label= param was confirmed on-device to set the device name reliably,
+# so no keycode-style disambiguation is needed here.
+_LED_LABEL_RED = "led-red"
+_LED_LABEL_GREEN = "led-green"
+_LED_LABEL_BLUE = "led-blue"
 
 # LED colour vocabulary - the single source of truth for what colours this
 # LED supports; COLOURS below is built from these rather than separately
@@ -26,34 +40,47 @@ class RGBLed:
         COLOUR_OFF: (0, 0, 0),
     }
 
-    def __init__(self, red_pin=_PIN_LED_R, green_pin=_PIN_LED_G, blue_pin=_PIN_LED_B):
-        # Required before the GPIO.setup() calls below. No other module sets
-        # this globally (each hardware module owns its own setmode call) -
-        # setmode is idempotent, so calling it here is safe even if another
-        # hardware object in the same process already has.
-        GPIO.setmode(GPIO.BCM)
-        self.pins = {"red": red_pin, "green": green_pin, "blue": blue_pin}
+    def __init__(self, red_label=_LED_LABEL_RED, green_label=_LED_LABEL_GREEN,
+                 blue_label=_LED_LABEL_BLUE):
+        self.paths = {
+            "red": self._resolve(red_label),
+            "green": self._resolve(green_label),
+            "blue": self._resolve(blue_label),
+        }
         self._running = asyncio.Event()
-        for pin in self.pins.values():
-            GPIO.setup(pin, GPIO.OUT)
-            GPIO.output(pin, GPIO.LOW)
+
+    @staticmethod
+    def _resolve(label: str) -> Path:
+        path = _LED_SYSFS_DIR / label / "brightness"
+        if not path.exists():
+            raise RuntimeError(
+                f"No gpio-led sysfs entry found for {label!r} - check "
+                "'dtoverlay=gpio-led,...' in /boot/firmware/config.txt and reboot"
+            )
+        try:
+            path.write_text("0")
+        except PermissionError as e:
+            raise RuntimeError(
+                f"No write access to {path} - check the LED udev rule "
+                "(/etc/udev/rules.d/99-radioglobe-leds.rules) is installed and "
+                "'udevadm control --reload-rules' has run"
+            ) from e
+        return path
 
     def set_color(self, color_name):
         color = self.COLOURS.get(color_name.lower(), (0, 0, 0))
-        GPIO.output(self.pins["red"], GPIO.HIGH if color[0] else GPIO.LOW)
-        GPIO.output(self.pins["green"], GPIO.HIGH if color[1] else GPIO.LOW)
-        GPIO.output(self.pins["blue"], GPIO.HIGH if color[2] else GPIO.LOW)
+        for channel, value in zip(("red", "green", "blue"), color):
+            self.paths[channel].write_text(str(value))
 
     def off(self):
         self.set_color(COLOUR_OFF)
 
     def start(self):
-        pass  # GPIO pins are configured at construction time
+        pass  # sysfs entries already exist once the gpio-led overlay is loaded
 
     async def stop(self):
-        """Turn the LED off and release its GPIO pins."""
+        """Turn the LED off. Nothing to release - the kernel driver owns the pins."""
         self.off()
-        GPIO.cleanup(list(self.pins.values()))
 
     async def flash(self, color: str, duration: float):
         """Turn the LED on for duration seconds, then off.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,7 @@ See [../../CONTRIBUTING.md](../../CONTRIBUTING.md) for how to submit changes.
 | `main_test.py` | GPIO + SPI | Encoder index diagnostic: shows current index, search area, and matched cities on latch. LED blinks red on latch. No audio. |
 | `streaming_cvlc_test.py` | GPIO + SPI + cvlc | Full stack test: encoders → city lookup → cvlc audio stream |
 | `async_streamer_test.py` | Network | Resolves and plays a list of internet radio URLs using the async aiohttp streamer (no Pi hardware needed) |
+| `rgb_led_gpio_led_test.py` | GPIO (experimental `gpio-led` overlay) | **Experimental.** Cycles the RGB LED through named colours by writing `/sys/class/leds/*/brightness` via the kernel's `leds-gpio` driver instead of `rgb_led.py`'s `RPi.GPIO`. Not wired into the app — see "Experimental: RGB LED via gpio-led overlay" below before running |
 
 ## Examples
 
@@ -43,6 +44,10 @@ python tests/integration/streaming_cvlc_test.py
 
 # Async streamer (network only)
 python tests/integration/async_streamer_test.py
+
+# Experimental: RGB LED via kernel leds-gpio driver (see setup section below
+# before running - needs sudo, no udev rule grants write access yet)
+sudo python tests/integration/rgb_led_gpio_led_test.py
 ```
 
 ## Hardware setup
@@ -78,9 +83,9 @@ pip install -e .
 | Top button | 5 | `BTN_1` (257) |
 | Mid button | 6 | `BTN_2` (258) |
 | Bottom button | 12 | `BTN_3` (259) |
-| LED red | 22 | — |
-| LED green | 23 | — |
-| LED blue | 24 | — |
+| LED red | 22 | — (experimental `leds-gpio` label `led-red`) |
+| LED green | 23 | — (experimental `leds-gpio` label `led-green`) |
+| LED blue | 24 | — (experimental `leds-gpio` label `led-blue`) |
 
 ### SPI
 
@@ -116,6 +121,38 @@ constants (see the pin table above) — device discovery matches on the
 keycode a device reports, **not** on its `label=` param, since the overlay
 was found on-device to not reliably set the evdev device name (every
 instance shows up as `button@<hex-gpio>` regardless of `label`).
+
+### Experimental: RGB LED via `gpio-led` overlay
+
+`rgb_led_gpio_led_test.py` tries driving the RGB status LED (R=22, G=23,
+B=24) through the kernel's `leds-gpio` driver instead of `rgb_led.py`'s
+`RPi.GPIO` output calls, mirroring the kernel-driver approach already
+adopted for the dial and all 4 buttons. **This is exploratory** — not
+wired into `rgb_led.py` or the running service.
+
+Requires adding, in `/boot/firmware/config.txt` (confirmed on-device via
+`dtoverlay -h gpio-led`):
+
+```
+dtoverlay=gpio-led,gpio=22,label=led-red
+dtoverlay=gpio-led,gpio=23,label=led-green
+dtoverlay=gpio-led,gpio=24,label=led-blue
+```
+
+Unlike `gpio-key`'s `label=` param (which doesn't reliably set the evdev
+device name, see above), `leds-gpio`'s `label=` reliably becomes the sysfs
+class device name directly — each LED shows up at
+`/sys/class/leds/<label>/brightness`, written with a plain `0`/`1`.
+
+**Known gap:** `/sys/class/leds/*/brightness` is `root:root` mode `644` on
+stock Raspberry Pi OS — confirmed on-device (tried writing to the existing
+`ACT` LED as the `radioglobe` user: `Permission denied`). Unlike
+`/dev/input/*` (readable via the `input` group), no udev rule grants
+non-root write access to LED class devices here. Run the test script with
+`sudo` for now. Adopting this for real would need a udev rule (e.g.
+`SUBSYSTEM=="leds", RUN+="/bin/chmod g+w /sys%p/brightness"`) so the
+running service doesn't need root — not set up, since this is still just
+an experiment.
 
 ### Calibration note
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,7 +15,7 @@ See [../../CONTRIBUTING.md](../../CONTRIBUTING.md) for how to submit changes.
 | `main_test.py` | GPIO + SPI | Encoder index diagnostic: shows current index, search area, and matched cities on latch. LED blinks red on latch. No audio. |
 | `streaming_cvlc_test.py` | GPIO + SPI + cvlc | Full stack test: encoders → city lookup → cvlc audio stream |
 | `async_streamer_test.py` | Network | Resolves and plays a list of internet radio URLs using the async aiohttp streamer (no Pi hardware needed) |
-| `rgb_led_gpio_led_test.py` | GPIO (experimental `gpio-led` overlay) | **Experimental.** Cycles the RGB LED through named colours by writing `/sys/class/leds/*/brightness` via the kernel's `leds-gpio` driver instead of `rgb_led.py`'s `RPi.GPIO`. Not wired into the app — see "Experimental: RGB LED via gpio-led overlay" below before running |
+| `rgb_led_gpio_led_test.py` | GPIO (kernel `gpio-led` overlay) | Low-level diagnostic: cycles the RGB LED through named colours by writing `/sys/class/leds/*/brightness` directly, with no `radioglobe` dependency — same role `encoder_hardware_test.py`/`jog_gpio_keys_test.py` play for the dial/buttons |
 
 ## Examples
 
@@ -45,9 +45,9 @@ python tests/integration/streaming_cvlc_test.py
 # Async streamer (network only)
 python tests/integration/async_streamer_test.py
 
-# Experimental: RGB LED via kernel leds-gpio driver (see setup section below
-# before running - needs sudo, no udev rule grants write access yet)
-sudo python tests/integration/rgb_led_gpio_led_test.py
+# RGB LED via kernel leds-gpio driver (no sudo needed once install.sh's
+# udev rule is installed - see setup section below)
+python tests/integration/rgb_led_gpio_led_test.py
 ```
 
 ## Hardware setup
@@ -83,9 +83,9 @@ pip install -e .
 | Top button | 5 | `BTN_1` (257) |
 | Mid button | 6 | `BTN_2` (258) |
 | Bottom button | 12 | `BTN_3` (259) |
-| LED red | 22 | — (experimental `leds-gpio` label `led-red`) |
-| LED green | 23 | — (experimental `leds-gpio` label `led-green`) |
-| LED blue | 24 | — (experimental `leds-gpio` label `led-blue`) |
+| LED red | 22 | — (`leds-gpio` label `led-red`) |
+| LED green | 23 | — (`leds-gpio` label `led-green`) |
+| LED blue | 24 | — (`leds-gpio` label `led-blue`) |
 
 ### SPI
 
@@ -122,37 +122,29 @@ keycode a device reports, **not** on its `label=` param, since the overlay
 was found on-device to not reliably set the evdev device name (every
 instance shows up as `button@<hex-gpio>` regardless of `label`).
 
-### Experimental: RGB LED via `gpio-led` overlay
+### RGB LED (kernel `gpio-led` overlay)
 
-`rgb_led_gpio_led_test.py` tries driving the RGB status LED (R=22, G=23,
-B=24) through the kernel's `leds-gpio` driver instead of `rgb_led.py`'s
-`RPi.GPIO` output calls, mirroring the kernel-driver approach already
-adopted for the dial and all 4 buttons. **This is exploratory** — not
-wired into `rgb_led.py` or the running service.
-
-Requires adding, in `/boot/firmware/config.txt` (confirmed on-device via
-`dtoverlay -h gpio-led`):
-
-```
-dtoverlay=gpio-led,gpio=22,label=led-red
-dtoverlay=gpio-led,gpio=23,label=led-green
-dtoverlay=gpio-led,gpio=24,label=led-blue
-```
+The RGB status LED (R=22, G=23, B=24) is driven through the kernel's
+`leds-gpio` driver, not directly via `RPi.GPIO` — the same kernel-driver
+approach already used for the dial and all 4 buttons. `install.sh` adds
+the required `dtoverlay=gpio-led,gpio=<pin>,label=<name>` line for each
+channel idempotently — a reboot is required for them to take effect
+(covered by the same reboot prompt `install.sh` already prints).
 
 Unlike `gpio-key`'s `label=` param (which doesn't reliably set the evdev
 device name, see above), `leds-gpio`'s `label=` reliably becomes the sysfs
 class device name directly — each LED shows up at
-`/sys/class/leds/<label>/brightness`, written with a plain `0`/`1`.
+`/sys/class/leds/<label>/brightness`, written with a plain `0`/`1`. Labels
+must match `rgb_led.py`'s `_LED_LABEL_RED`/`_GREEN`/`_BLUE` constants (see
+the pin table above).
 
-**Known gap:** `/sys/class/leds/*/brightness` is `root:root` mode `644` on
-stock Raspberry Pi OS — confirmed on-device (tried writing to the existing
-`ACT` LED as the `radioglobe` user: `Permission denied`). Unlike
-`/dev/input/*` (readable via the `input` group), no udev rule grants
-non-root write access to LED class devices here. Run the test script with
-`sudo` for now. Adopting this for real would need a udev rule (e.g.
-`SUBSYSTEM=="leds", RUN+="/bin/chmod g+w /sys%p/brightness"`) so the
-running service doesn't need root — not set up, since this is still just
-an experiment.
+**Permissions:** `/sys/class/leds/*/brightness` is `root:root` mode `644`
+by default — unlike `/dev/input/*` (readable via the `input` group), no
+kernel/overlay mechanism grants non-root write access on its own.
+`install.sh` also installs a udev rule
+(`/etc/udev/rules.d/99-radioglobe-leds.rules`) granting the `gpio` group
+(which `radioglobe` is already a member of) write access, so neither the
+running service nor `rgb_led_gpio_led_test.py` need `sudo`.
 
 ### Calibration note
 

--- a/tests/integration/led_test.py
+++ b/tests/integration/led_test.py
@@ -10,9 +10,12 @@ import asyncio
 import time
 import pytest
 
-GPIO = pytest.importorskip("RPi.GPIO", reason="Requires Raspberry Pi hardware")
-
 from radioglobe.rgb_led import RGBLed, COLOUR_RED, COLOUR_GREEN, COLOUR_BLUE
+
+try:
+    RGBLed()
+except RuntimeError as e:
+    pytest.skip(str(e), allow_module_level=True)
 
 
 async def scheduler():

--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -13,13 +13,17 @@ import asyncio
 import argparse
 import pytest
 
-GPIO = pytest.importorskip("RPi.GPIO", reason="Requires Raspberry Pi hardware")
 pytest.importorskip("spidev", reason="Requires SPI hardware")
 
 from radioglobe import database
 from radioglobe.rgb_led import RGBLed, COLOUR_RED
 from radioglobe.radio_config import STATIONS_JSON
 from radioglobe.positional_encoders import PositionalEncoders
+
+try:
+    RGBLed()
+except RuntimeError as e:
+    pytest.skip(str(e), allow_module_level=True)
 
 
 async def main(stickiness: int, fuzziness: int):

--- a/tests/integration/rgb_led_gpio_led_test.py
+++ b/tests/integration/rgb_led_gpio_led_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+rgb_led_gpio_led_test.py
+
+Experiment: drive the RGB status LED (R=22, G=23, B=24) via the kernel's
+leds-gpio driver (dtoverlay=gpio-led) instead of rgb_led.py's RPi.GPIO
+output calls, mirroring the kernel-driver approach already adopted for
+the dial (rotary_encoder) and all 4 buttons (gpio-keys).
+
+Requires, in /boot/firmware/config.txt:
+
+    dtoverlay=gpio-led,gpio=22,label=led-red
+    dtoverlay=gpio-led,gpio=23,label=led-green
+    dtoverlay=gpio-led,gpio=24,label=led-blue
+
+KNOWN GAP: /sys/class/leds/*/brightness is root:root mode 644 on stock
+Raspberry Pi OS - no udev rule grants the radioglobe user write access
+(confirmed on-device: writing to the existing ACT LED as radioglobe was
+denied, unlike /dev/input/* which works via the `input` group). Run this
+script with sudo for now:
+
+    sudo python3 rgb_led_gpio_led_test.py
+
+Production adoption would need a udev rule (e.g. SUBSYSTEM=="leds",
+RUN+="/bin/chmod g+w /sys%p/brightness") so the running service doesn't
+need root - not set up yet, this is purely an experiment.
+
+This program does not import anything from radioglobe - it's a standalone
+diagnostic, not wired into the app.
+"""
+
+import time
+from pathlib import Path
+
+LEDS = {
+    "red": Path("/sys/class/leds/led-red/brightness"),
+    "green": Path("/sys/class/leds/led-green/brightness"),
+    "blue": Path("/sys/class/leds/led-blue/brightness"),
+}
+
+# Mirrors radioglobe.rgb_led.RGBLed.COLOURS, plus a couple of extra
+# combinations to prove independent per-channel control works.
+COLOURS = {
+    "red": (1, 0, 0),
+    "green": (0, 1, 0),
+    "blue": (0, 0, 1),
+    "yellow": (1, 1, 0),
+    "cyan": (0, 1, 1),
+    "magenta": (1, 0, 1),
+    "white": (1, 1, 1),
+    "off": (0, 0, 0),
+}
+
+
+def set_color(name: str) -> None:
+    r, g, b = COLOURS[name]
+    for channel, value in zip(("red", "green", "blue"), (r, g, b)):
+        LEDS[channel].write_text(str(value))
+
+
+def main():
+    for path in LEDS.values():
+        if not path.exists():
+            raise RuntimeError(
+                f"{path} not found - check 'dtoverlay=gpio-led,...' lines in "
+                "/boot/firmware/config.txt and reboot"
+            )
+
+    print("Cycling colours (Ctrl+C to stop)...")
+    try:
+        while True:
+            for name in COLOURS:
+                print(f"  {name}")
+                set_color(name)
+                time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        set_color("off")
+        print("\nFinished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/streaming_cvlc_test.py
+++ b/tests/integration/streaming_cvlc_test.py
@@ -5,7 +5,6 @@ Test harness for async cvlc streamer
 import asyncio
 import pytest
 
-GPIO = pytest.importorskip("RPi.GPIO", reason="Requires Raspberry Pi hardware")
 pytest.importorskip("spidev", reason="Requires SPI hardware")
 
 from radioglobe import database
@@ -13,6 +12,11 @@ from radioglobe.rgb_led import RGBLed, COLOUR_RED
 from radioglobe.radio_config import STATIONS_JSON
 from radioglobe.positional_encoders import PositionalEncoders
 from streaming.streaming_cvlc import StreamerCVLC
+
+try:
+    RGBLed()
+except RuntimeError as e:
+    pytest.skip(str(e), allow_module_level=True)
 
 
 async def get_cities(lat, lon, city_map, offsets) -> list:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,16 +3,14 @@ import sys
 import unittest
 from unittest.mock import MagicMock
 
-# main.py imports radioglobe.rgb_led (for COLOUR_* constants), which
-# imports RPi.GPIO at module scope, and radioglobe.buttons (for
-# create_button_manager/ButtonCallbacks), which now imports evdev at module
-# scope (buttons.py reads all 4 buttons via the kernel gpio-keys driver) -
-# stub both before importing radioglobe.main so this test can run on any
-# machine, same as tests/buttons_test.py does for evdev. radioglobe.hal
-# (Protocols + fakes) needs no such stub, since it never imports
-# radioglobe.buttons, radioglobe.rgb_led, or radioglobe.main.
-sys.modules.setdefault("RPi", MagicMock())
-sys.modules.setdefault("RPi.GPIO", MagicMock())
+# main.py imports radioglobe.buttons (for create_button_manager/
+# ButtonCallbacks), which imports evdev at module scope (buttons.py reads
+# all 4 buttons via the kernel gpio-keys driver) - stub it before importing
+# radioglobe.main so this test can run on any machine, same as
+# tests/buttons_test.py does. radioglobe.rgb_led now uses only pathlib
+# (stdlib) since its gpio-led migration, so no RPi.GPIO stub is needed any
+# more. radioglobe.hal (Protocols + fakes) needs no stub at all, since it
+# never imports radioglobe.buttons, radioglobe.rgb_led, or radioglobe.main.
 sys.modules.setdefault("evdev", MagicMock())
 
 from radioglobe.constants import MODE_STATION  # noqa: E402


### PR DESCRIPTION
## Summary

- `rgb_led.py` now drives all 3 LED channels via the kernel's `leds-gpio` driver + sysfs (`/sys/class/leds/<label>/brightness`) instead of `RPi.GPIO.output()` — the same kernel-driver approach `dial.py` and `buttons.py` already use. Unlike `gpio-key`'s `label=` param, `gpio-led`'s `label=` was confirmed on-device to reliably set the sysfs device name, so no keycode-style disambiguation is needed.
- `max_brightness` is `1` on these LEDs (binary on/off only, confirmed on-device) — identical to what `RPi.GPIO.output(HIGH/LOW)` already gave, so no brightness/dimming behavior changes. (The "LED is very bright" issue raised during testing is a hardware fix — series resistor — out of scope here.)
- `rgb_led.py` was the *last* module using `RPi.GPIO` — migrating it means `import RPi.GPIO` has zero remaining consumers in `src/` (verified by grep). Removed `lgpio`/`rpi-lgpio` from `pyproject.toml`'s `pi` extra entirely, and the `swig`/`liblgpio-dev` apt packages from `install.sh` (they existed only to build `lgpio`'s bindings).
- New gap the dial/button migrations didn't have: LED sysfs brightness files are `root:root` mode `644` by default, unlike `/dev/input/*` (readable via the `input` group). `install.sh` installs a udev rule granting the `gpio` group write access, with `udevadm` reload/trigger so re-running `install.sh` fixes permissions on LEDs that already exist from a prior boot.
- `tests/main_test.py`'s stub narrowed to `evdev`-only — confirmed `radioglobe.main`/`cli` now import with only `evdev` stubbed, no `RPi.GPIO` needed at all. `led_test.py`/`main_test.py`/`streaming_cvlc_test.py`'s `RPi.GPIO` importorskip guards replaced with a try/except around `RGBLed()` construction, mirroring `dial_test.py`'s existing pattern.
- `ARCHITECTURE.md` updated throughout (§1, §3, §4.2, §4.10, §4.14, §8, §9).

## Test plan
- [x] Full unit suite passes (`PYTHONPATH=src python -m pytest tests/ -q` — 71 passed)
- [x] `ruff check` clean
- [x] Confirmed zero remaining `import RPi`/`RPi.GPIO` anywhere in `src/`/`tests/`
- [x] Validated on real hardware: standalone diagnostic and the real `RGBLed` class both work without `sudo` (udev rule confirmed working)
- [x] Full `radioglobe.service` restart clean with the new `rgb_led.py`
- [x] Real Jog button press confirmed LED feedback working end-to-end through the running app (green flash on press, correctly turns off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)