### PR TITLE
Remove RGBLed.start() and AudioPlayer.start() - dead code

### DIFF
--- a/src/radioglobe/audio_async.py
+++ b/src/radioglobe/audio_async.py
@@ -13,9 +13,6 @@ class AudioPlayer:
         self.player = self.instance.media_player_new()
         self.current_url = None
 
-    def start(self):
-        pass  # VLC instance is ready at construction time
-
     def play(self, url: str):
         """Play a new URL stream, stopping current playback if needed."""
         if self.player.is_playing():

--- a/src/radioglobe/hal/fake.py
+++ b/src/radioglobe/hal/fake.py
@@ -138,7 +138,6 @@ class FakeRGBLed:
     def __init__(self):
         self.calls: list = []
         self.current_color: Optional[str] = None
-        self.started = False
         self.stopped = False
 
     def set_color(self, color_name: str) -> None:
@@ -147,9 +146,6 @@ class FakeRGBLed:
 
     def off(self) -> None:
         self.set_color("off")
-
-    def start(self) -> None:
-        self.started = True
 
     async def stop(self) -> None:
         self.off()
@@ -206,10 +202,6 @@ class FakeAudioPlayer:
         self.volume = 100
         self._error = False
         self.stopped_calls = 0
-        self.started = False
-
-    def start(self) -> None:
-        self.started = True
 
     def play(self, url: str) -> None:
         self.current_url = url

--- a/src/radioglobe/hal/protocols.py
+++ b/src/radioglobe/hal/protocols.py
@@ -14,15 +14,22 @@ from radioglobe.coordinates import Coordinate
 
 
 class HardwareComponent(Protocol):
-    """Shared start/stop shape common to all hardware roles."""
+    """Shared teardown shape common to all hardware roles.
 
-    def start(self) -> None: ...
+    Deliberately does NOT declare start() - RGBLed and AudioPlayer have no
+    start() at all (construction alone makes them ready; see rgb_led.py /
+    audio_async.py), while the other four roles do. Each role protocol
+    below declares start() only where the concrete class has one.
+    """
+
     async def stop(self) -> None: ...
 
 
 @runtime_checkable
 class DialProtocol(HardwareComponent, Protocol):
     queue: "asyncio.Queue[int]"
+
+    def start(self) -> None: ...
 
 
 @runtime_checkable
@@ -36,12 +43,14 @@ class PositionalEncodersProtocol(HardwareComponent, Protocol):
     def is_latched(self) -> bool: ...
     def get_calibration(self) -> dict: ...
     def restore_calibration(self, state: dict) -> None: ...
+    def start(self) -> None: ...
 
 
 @runtime_checkable
 class ButtonManagerProtocol(HardwareComponent, Protocol):
     event_queue: "asyncio.Queue"
 
+    def start(self) -> None: ...
     async def handle_events(self) -> None: ...
     def get_event_nowait(self) -> Optional[tuple]: ...
 
@@ -57,6 +66,7 @@ class RGBLedProtocol(HardwareComponent, Protocol):
 class DisplayProtocol(HardwareComponent, Protocol):
     changed: asyncio.Event
 
+    def start(self) -> None: ...
     def message(
         self, line_1: str = "", line_2: str = "", line_3: str = "", line_4: str = ""
     ) -> None: ...

--- a/src/radioglobe/rgb_led.py
+++ b/src/radioglobe/rgb_led.py
@@ -75,9 +75,6 @@ class RGBLed:
     def off(self):
         self.set_color(COLOUR_OFF)
 
-    def start(self):
-        pass  # sysfs entries already exist once the gpio-led overlay is loaded
-
     async def stop(self):
         """Turn the LED off. Nothing to release - the kernel driver owns the pins."""
         self.off()


### PR DESCRIPTION
## Summary
- `RGBLed.start()` and `AudioPlayer.start()` were no-op `pass` bodies never called from `main.py` (only their `stop()` runs, in teardown) - unreachable code that misleadingly suggested they were part of the startup sequence.
- Removed both methods; construction alone already does all the setup they need (sysfs paths exist once the gpio-led overlay loads; the VLC instance is ready at `__init__`).
- Updated `hal/protocols.py` (start() moved back out of the shared `HardwareComponent` into just the four role protocols that still have one) and `hal/fake.py` (dropped the matching `start()`/`started` from `FakeRGBLed`/`FakeAudioPlayer`) to match.

Second item from the ranked HAL-layer audit (after #29). Decision on removing vs. keeping was confirmed with Peter before implementing.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)