### PR TITLE
Log SPI parity failures in PositionalEncoders

### DIFF
--- a/src/radioglobe/positional_encoders.py
+++ b/src/radioglobe/positional_encoders.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import spidev  # type: ignore
 
@@ -90,6 +91,7 @@ class PositionalEncoders:
             if self.check_parity(raw_reading):
                 readings.append(raw_reading >> 6)
             else:
+                logging.debug(f"SPI parity check failed for encoder {device} (raw={raw_reading:#06x})")
                 return None
 
         return readings


### PR DESCRIPTION
## Summary
- `positional_encoders.py` had no `import logging` and no logging calls anywhere, unlike every other HAL module. Bad SPI parity reads were silently swallowed in `read_spi()`, so a genuinely faulty/stuck encoder is indistinguishable from normal idle behaviour when debugging on-device.
- Added a `logging.debug` call noting which encoder device (0 or 1) failed its parity check and the raw reading, matching the low-volume debug-level logging used elsewhere in the HAL (`rgb_led.py`, `audio_async.py`) for routine/expected conditions - deliberately `debug`, not `warning`, since this loop polls at 20Hz and transient parity noise is expected per the EMS22A50 datasheet (see `UNLATCH_CONFIRM_THRESHOLD` comment in the same file).

Third item from the ranked HAL-layer audit (after #29, #30).

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)