### PR TITLE
Unify Display's stop() with PositionalEncoders' cancellation idiom

### DIFF
--- a/src/radioglobe/display.py
+++ b/src/radioglobe/display.py
@@ -17,7 +17,6 @@ class Display:
         )
         self.buffer = ["" for _ in range(_DISPLAY_ROWS)]
         self.changed = asyncio.Event()
-        self.running = True
         self._task = None
         logging.info("Display initialized")
 
@@ -29,14 +28,16 @@ class Display:
 
     async def stop(self):
         """Stop the background display loop and wait for the task to finish."""
-        self.running = False
-        self.changed.set()
         if self._task:
-            await self._task
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
             logging.info("Display loop stopped")
 
     async def _display_loop(self):
-        while self.running:
+        while True:
             await self.changed.wait()
             try:
                 for line_num in range(_DISPLAY_ROWS):


### PR DESCRIPTION
## Summary
- `display.py` used a cooperative `running` flag plus setting `changed` to wake and stop `_display_loop()`. `positional_encoders.py` (same shape of problem: own a background asyncio task, stop it in `stop()`) used `task.cancel()` instead. Two incompatible idioms for the same problem.
- Switched `Display` to the `task.cancel()` + `await` + catch `asyncio.CancelledError` pattern, matching `PositionalEncoders.stop()` exactly. `_display_loop()` blocks on `self.changed.wait()`, and `cancel()` interrupts that wait immediately, so the cooperative-flag dance (`running = False` + `changed.set()` just to wake the loop) wasn't buying anything here.
- Removed the now-unused `self.running` attribute; `_display_loop()`'s `while self.running:` became `while True:` since cancellation now owns loop termination.

Fourth and last item in the current ranked HAL-layer batch (after #29, #30, #31). Per Peter, this batch stays on `develop` and gets released together as one tagged version rather than per-PR.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)