### PR TITLE
Reorder App teardown loop to reverse-of-start, document the exceptions

### DIFF
--- a/src/radioglobe/main.py
+++ b/src/radioglobe/main.py
@@ -302,7 +302,12 @@ class App:
         finally:
             if self._stream_task and not self._stream_task.done():
                 self._stream_task.cancel()
-            for hw in [self.audio_player, self.dial, self.encoders, self.display, self.led, button_manager]:
+            # Reverse of the start order above (button_manager, display,
+            # encoders, dial). audio_player and led are appended even though
+            # they were never started — both accept stop() safely without a
+            # prior start(), since neither class has a start() at all (see
+            # rgb_led.py / audio_async.py).
+            for hw in [button_manager, self.display, self.encoders, self.dial, self.audio_player, self.led]:
                 await hw.stop()
 
 


### PR DESCRIPTION
## Summary
- `main.py`'s teardown loop (`for hw in [self.audio_player, self.dial, self.encoders, self.display, self.led, button_manager]: await hw.stop()`) matched neither construction order, actual start order, nor reverse-start order — it read as arbitrary.
- Reordered to LIFO relative to the real start sequence (`button_manager`, `display`, `encoders`, `dial` — see `run()` above it), and added a comment explaining why `audio_player`/`led` are still appended even though they're never started: both accept `stop()` safely because neither class has a `start()` at all (per PR #30).

Fifth item, first of the deferred P3 batch, following #29-#32.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)