### PR TITLE
Log full traceback for Display's defensive write-failure catch

### DIFF
--- a/src/radioglobe/display.py
+++ b/src/radioglobe/display.py
@@ -42,8 +42,8 @@ class Display:
             try:
                 for line_num in range(_DISPLAY_ROWS):
                     self.lcd.printline(line_num, self.buffer[line_num])
-            except Exception as e:
-                logging.error(f"Display write failed: {e}")
+            except Exception:
+                logging.exception("Display write failed")
             self.changed.clear()
             await asyncio.sleep(0.1)
 


### PR DESCRIPTION
## Summary
Audited error-handling/logging across all six HAL modules (dial.py, rgb_led.py, display.py, audio_async.py, positional_encoders.py, buttons.py) to define a consistent policy. Most of it already sorts cleanly into categories:

- **Construction-time hardware absence** → `raise RuntimeError(...)` with an actionable message (`dial.py`, `rgb_led.py`, `audio_async.py`) - consistent, no change.
- **Routine/expected runtime variance** → `logging.debug(...)` (`audio_async.py`, `rgb_led.py`, `positional_encoders.py`) - consistent, no change.
- **Genuine non-fatal anomalies** → `logging.warning(...)` (`dial.py`'s rotary-device name mismatch) - only one example, but a coherent category.

The one real inconsistency: two modules have a **defensive broad `except Exception` around a shared loop's per-iteration work**, so one bad iteration can't kill dispatch for everything else - `display.py`'s `_display_loop()` (LCD writes) and `buttons.py`'s `handle_events()` (user callbacks). `buttons.py` already logs via `logging.exception(...)`, capturing the traceback; `display.py` only logged `str(e)`. Since the entire point of catching broadly is not knowing what will go wrong, the traceback is the useful part - aligned `display.py` to match.

`display.py` also has `logging.info` lifecycle logs (init/start/stop/message-set) that no other HAL module has - that's a different axis (operational visibility, not error severity), so left out of scope rather than adding matching info-logging to five more classes.

Sixth item in the P3 batch, following #29-#33.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)