### PR TITLE
Fill in missing type hints across the HAL layer and its Fakes

### DIFF
--- a/src/radioglobe/audio_async.py
+++ b/src/radioglobe/audio_async.py
@@ -3,7 +3,7 @@ import logging
 
 
 class AudioPlayer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.instance = vlc.Instance(
             "--input-repeat=-1",
             "--network-caching=2000",  # 2 s network buffer absorbs stream jitter
@@ -13,7 +13,7 @@ class AudioPlayer:
         self.player = self.instance.media_player_new()
         self.current_url = None
 
-    def play(self, url: str):
+    def play(self, url: str) -> None:
         """Play a new URL stream, stopping current playback if needed."""
         if self.player.is_playing():
             self.player.stop()
@@ -24,7 +24,7 @@ class AudioPlayer:
         self.player.play()
         logging.debug(f"🔊 Playing: {url}")
 
-    def change_volume(self, delta, min_volume=10, max_volume=100) -> int:
+    def change_volume(self, delta: int, min_volume: int = 10, max_volume: int = 100) -> int:
         """Adjust volume by delta, clamped between min and max."""
         current_volume = self.player.audio_get_volume()
         new_volume = max(min_volume, min(max_volume, current_volume + delta))
@@ -51,7 +51,7 @@ class AudioPlayer:
         state = self.player.get_state()
         return state not in (vlc.State.Playing, vlc.State.Paused)
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop playback if something is playing."""
         if self.player.is_playing():
             self.player.stop()

--- a/src/radioglobe/buttons.py
+++ b/src/radioglobe/buttons.py
@@ -56,7 +56,7 @@ MID_BUTTON    = ButtonDefinition("Mid",    _PIN_BTN_MID,    keycode=_KEYCODE_BTN
 BOTTOM_BUTTON = ButtonDefinition("Bottom", _PIN_BTN_BOTTOM, keycode=_KEYCODE_BTN_BOTTOM)
 
 
-def _fire(callback):
+def _fire(callback: Optional[Callable]) -> None:
     """Invoke a sync or async callback without blocking the caller."""
     if callback is None:
         return
@@ -75,8 +75,9 @@ class Button:
     touches real hardware unless start() is actually called.
     """
 
-    def __init__(self, name, keycode, long_press_threshold=1.0,
-                 short_cb=None, long_cb=None, press_cb=None):
+    def __init__(self, name: str, keycode: int, long_press_threshold: float = 1.0,
+                 short_cb: Optional[Callable] = None, long_cb: Optional[Callable] = None,
+                 press_cb: Optional[Callable] = None) -> None:
         self.name = name
         self.keycode = keycode
         self.long_press_threshold = long_press_threshold
@@ -101,7 +102,7 @@ class Button:
             "'dtoverlay=gpio-key,...' in /boot/firmware/config.txt and reboot"
         )
 
-    def _on_readable(self):
+    def _on_readable(self) -> None:
         for event in self._device.read():
             if event.type != ecodes.EV_KEY or event.code != self.keycode:
                 continue
@@ -114,13 +115,13 @@ class Button:
                 kind = "long" if held >= self.long_press_threshold else "short"
                 self._event_queue.put_nowait((self.name, kind))
 
-    def start(self, event_queue: asyncio.Queue):
+    def start(self, event_queue: asyncio.Queue) -> None:
         self._event_queue = event_queue
         self._device = self._find_button_device(self.keycode)
         self._loop = asyncio.get_running_loop()
         self._loop.add_reader(self._device.fd, self._on_readable)
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self._loop is not None and self._device is not None:
             self._loop.remove_reader(self._device.fd)
         if self._device is not None:
@@ -128,7 +129,7 @@ class Button:
 
 
 class ButtonManager:
-    def __init__(self, button_definitions, long_press_threshold=1.0):
+    def __init__(self, button_definitions: list[ButtonDefinition], long_press_threshold: float = 1.0) -> None:
         self.event_queue: asyncio.Queue = asyncio.Queue()
         self.buttons = [
             Button(
@@ -138,16 +139,16 @@ class ButtonManager:
             for d in button_definitions
         ]
 
-    def start(self):
+    def start(self) -> None:
         for btn in self.buttons:
             btn.start(self.event_queue)
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Release every managed button's evdev device."""
         for btn in self.buttons:
             await btn.stop()
 
-    async def handle_events(self):
+    async def handle_events(self) -> None:
         """Continuously process events with the appropriate handler.
 
         A handler that raises must not kill this loop - it's the single
@@ -169,7 +170,7 @@ class ButtonManager:
                         except Exception:
                             logging.exception(f"Button handler failed: {btn.name} {event_type}")
 
-    def get_event_nowait(self):
+    def get_event_nowait(self) -> Optional[tuple]:
         try:
             return self.event_queue.get_nowait()
         except asyncio.QueueEmpty:

--- a/src/radioglobe/dial.py
+++ b/src/radioglobe/dial.py
@@ -8,7 +8,7 @@ _POLARITY = 1  # flip to -1 if on-device verification shows inverted direction
 
 
 class Dial:
-    def __init__(self):
+    def __init__(self) -> None:
         self.queue: asyncio.Queue[int] = asyncio.Queue()
         self._device = self._find_rotary_device()
         self._loop = None
@@ -29,7 +29,7 @@ class Dial:
             "'dtoverlay=rotary-encoder,...' in /boot/firmware/config.txt and reboot"
         )
 
-    def _on_readable(self):
+    def _on_readable(self) -> None:
         for event in self._device.read():
             if event.type == ecodes.EV_REL and event.code == ecodes.REL_X:
                 if event.value > 0:
@@ -37,11 +37,11 @@ class Dial:
                 elif event.value < 0:
                     self.queue.put_nowait(_POLARITY * -1)
 
-    def start(self):
+    def start(self) -> None:
         self._loop = asyncio.get_running_loop()
         self._loop.add_reader(self._device.fd, self._on_readable)
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self._loop is not None:
             self._loop.remove_reader(self._device.fd)
         self._device.close()

--- a/src/radioglobe/display.py
+++ b/src/radioglobe/display.py
@@ -11,7 +11,7 @@ _DISPLAY_ROWS = 4
 
 
 class Display:
-    def __init__(self):
+    def __init__(self) -> None:
         self.lcd = liquidcrystal_i2c.LiquidCrystal_I2C(
             _I2C_LCD_ADDR, _DISPLAY_I2C_PORT, numlines=_DISPLAY_ROWS
         )
@@ -20,13 +20,13 @@ class Display:
         self._task = None
         logging.info("Display initialized")
 
-    def start(self):
+    def start(self) -> None:
         """Start the background display update loop."""
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._display_loop())
             logging.info("Display loop started")
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop the background display loop and wait for the task to finish."""
         if self._task:
             self._task.cancel()
@@ -36,7 +36,7 @@ class Display:
                 pass
             logging.info("Display loop stopped")
 
-    async def _display_loop(self):
+    async def _display_loop(self) -> None:
         while True:
             await self.changed.wait()
             try:
@@ -47,7 +47,7 @@ class Display:
             self.changed.clear()
             await asyncio.sleep(0.1)
 
-    def message(self, line_1="", line_2="", line_3="", line_4=""):
+    def message(self, line_1: str = "", line_2: str = "", line_3: str = "", line_4: str = "") -> None:
         self.buffer[0] = line_1[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.buffer[1] = line_2[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.buffer[2] = line_3[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
@@ -55,15 +55,15 @@ class Display:
         self.changed.set()
         logging.info(f"Message set: {[line_1, line_2, line_3, line_4]}")
 
-    def show_station(self, coords: Coordinate, city: str, station_name: str):
+    def show_station(self, coords: Coordinate, city: str, station_name: str) -> None:
         """Show the current city and station."""
         self.update(coords, city, volume=0, station=station_name, arrows=False)
 
-    def show_status(self, status: str, coords: Optional[Coordinate] = None):
+    def show_status(self, status: str, coords: Optional[Coordinate] = None) -> None:
         """Show a status message (e.g. calibrating, shutdown)."""
         self.update(coords or Coordinate(0, 0), status, volume=0, station="", arrows=False)
 
-    def update(self, coords: Coordinate, location: str, volume: int, station: str, arrows: bool):
+    def update(self, coords: Coordinate, location: str, volume: int, station: str, arrows: bool) -> None:
         self.buffer[0] = str(coords)[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.buffer[1] = location[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
 

--- a/src/radioglobe/hal/fake.py
+++ b/src/radioglobe/hal/fake.py
@@ -17,7 +17,7 @@ from typing import Optional
 class FakeDial:
     """Simulate dial turns via push_turn(); real Dial pushes +-1 ints too."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.queue: "asyncio.Queue[int]" = asyncio.Queue()
         self.started = False
         self.stopped = False
@@ -36,7 +36,7 @@ class FakeDial:
 class FakePositionalEncoders:
     """Test hook: set_position()/latch() drive App._encoder_loop()."""
 
-    def __init__(self, latitude_offset=0, longitude_offset=0):
+    def __init__(self, latitude_offset: int = 0, longitude_offset: int = 0) -> None:
         self.latitude = 0
         self.longitude = 0
         self.latitude_offset = latitude_offset
@@ -94,7 +94,7 @@ class FakePositionalEncoders:
 class FakeButtonManager:
     """Test hook: inject_event() drives handle_events() dispatch, no GPIO involved."""
 
-    def __init__(self, button_definitions, long_press_threshold=1.0):
+    def __init__(self, button_definitions, long_press_threshold: float = 1.0) -> None:
         self.button_definitions = list(button_definitions)
         self.event_queue: "asyncio.Queue" = asyncio.Queue()
         self.started = False
@@ -135,7 +135,7 @@ class FakeButtonManager:
 class FakeRGBLed:
     """Records every set_color()/flash() call for assertions."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.calls: list = []
         self.current_color: Optional[str] = None
         self.stopped = False
@@ -162,7 +162,7 @@ class FakeDisplay:
 
     ROWS = 4
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.buffer = ["" for _ in range(self.ROWS)]
         self.changed = asyncio.Event()
         self.calls: list = []
@@ -196,7 +196,7 @@ class FakeDisplay:
 class FakeAudioPlayer:
     """Records play() calls; error state settable via set_error() for stream-monitor tests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.current_url: Optional[str] = None
         self.played: list = []
         self.volume = 100

--- a/src/radioglobe/positional_encoders.py
+++ b/src/radioglobe/positional_encoders.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Optional
 
 import spidev  # type: ignore
 
@@ -7,7 +8,7 @@ from .database import _ENCODER_RESOLUTION
 
 
 class PositionalEncoders:
-    def __init__(self, latitude_offset=0, longitude_offset=0):
+    def __init__(self, latitude_offset: int = 0, longitude_offset: int = 0) -> None:
         self.latch_stickiness = None
         self.latitude = 0
         self.longitude = 0
@@ -21,12 +22,12 @@ class PositionalEncoders:
         # Used to safely stop the task
         self._task = None
 
-    def zero(self):
+    def zero(self) -> list:
         self.latitude_offset = (_ENCODER_RESOLUTION // 2) - self.latitude
         self.longitude_offset = (_ENCODER_RESOLUTION // 2) - self.longitude
         return [self.latitude_offset, self.longitude_offset]
 
-    def reset_latch(self):
+    def reset_latch(self) -> None:
         """Unlock the stickiness so the main loop can re-latch to a new position."""
         self.latch_stickiness = None
 
@@ -35,12 +36,12 @@ class PositionalEncoders:
             self.longitude + self.longitude_offset
         ) % _ENCODER_RESOLUTION
 
-    def latch(self, latitude: int, longitude: int, stickiness: int):
+    def latch(self, latitude: int, longitude: int, stickiness: int) -> None:
         self.latch_stickiness = stickiness
         self.latitude = (latitude - self.latitude_offset) % _ENCODER_RESOLUTION
         self.longitude = (longitude - self.longitude_offset) % _ENCODER_RESOLUTION
 
-    def is_latched(self):
+    def is_latched(self) -> bool:
         return self.latch_stickiness is not None
 
     def get_calibration(self) -> dict:
@@ -52,7 +53,7 @@ class PositionalEncoders:
             "lon_offset": self.longitude_offset,
         }
 
-    def restore_calibration(self, state: dict):
+    def restore_calibration(self, state: dict) -> None:
         """Restore position/calibration from a dict produced by get_calibration().
 
         Also marks the encoders as latched, since a restored position always
@@ -64,7 +65,7 @@ class PositionalEncoders:
         self.longitude_offset = state.get("lon_offset")
         self.latch_stickiness = True
 
-    def check_parity(self, reading: int):
+    def check_parity(self, reading: int) -> bool:
         reading_without_parity_bit = reading >> 1
         parity_bit = reading & 0b1
 
@@ -75,7 +76,7 @@ class PositionalEncoders:
 
         return parity_bit == computed_parity
 
-    def read_spi(self):
+    def read_spi(self) -> Optional[list]:
         BUS = 0
         readings = []
 
@@ -102,7 +103,7 @@ class PositionalEncoders:
     # without having to raise STICKINESS itself.
     UNLATCH_CONFIRM_THRESHOLD = 2
 
-    async def run_encoder(self):
+    async def run_encoder(self) -> None:
         # while self._running:
         unlatch_confirm_count = 0
         while self._task:
@@ -134,10 +135,10 @@ class PositionalEncoders:
 
             await asyncio.sleep(0.05)
 
-    def start(self):
+    def start(self) -> None:
         self._task = asyncio.create_task(self.run_encoder())
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self._task:
             self._task.cancel()
             try:

--- a/src/radioglobe/rgb_led.py
+++ b/src/radioglobe/rgb_led.py
@@ -40,8 +40,8 @@ class RGBLed:
         COLOUR_OFF: (0, 0, 0),
     }
 
-    def __init__(self, red_label=_LED_LABEL_RED, green_label=_LED_LABEL_GREEN,
-                 blue_label=_LED_LABEL_BLUE):
+    def __init__(self, red_label: str = _LED_LABEL_RED, green_label: str = _LED_LABEL_GREEN,
+                 blue_label: str = _LED_LABEL_BLUE) -> None:
         self.paths = {
             "red": self._resolve(red_label),
             "green": self._resolve(green_label),
@@ -67,15 +67,15 @@ class RGBLed:
             ) from e
         return path
 
-    def set_color(self, color_name):
+    def set_color(self, color_name: str) -> None:
         color = self.COLOURS.get(color_name.lower(), (0, 0, 0))
         for channel, value in zip(("red", "green", "blue"), color):
             self.paths[channel].write_text(str(value))
 
-    def off(self):
+    def off(self) -> None:
         self.set_color(COLOUR_OFF)
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Turn the LED off. Nothing to release - the kernel driver owns the pins."""
         self.off()
 


### PR DESCRIPTION
## Summary
Type-hint coverage was inconsistent within every HAL module - some methods fully typed, adjacent ones with zero annotations. Added missing parameter/return annotations across `dial.py`, `positional_encoders.py`, `buttons.py`, `rgb_led.py`, `display.py`, `audio_async.py`, and mirrored the `__init__` return-type coverage into `hal/fake.py`'s six Fakes.

- Matched types already declared in `hal/protocols.py` where a method is part of a role Protocol (e.g. bare `tuple`/`list`/`dict` return types, not their generic forms - that's what the Protocols themselves use).
- Scoped to **method signatures only** (params + return types). Deliberately left instance-attribute annotations (`self.x: T = ...`) untouched - several would interact with an existing, separate, unfixed gap in `PositionalEncoders.restore_calibration()`'s untyped `dict.get()` calls (pre-existing pyright `reportGeneralTypeIssues` noise, visible before this PR too), which is out of scope here.

Eighth item in the ranked HAL-layer audit, following #29-#35. Only task #10 (deferring hardware I/O out of `__init__`) remains, and that one needs a design conversation before starting.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)