### PR TITLE
Defer hardware I/O out of __init__ across the whole HAL layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -326,8 +326,8 @@ Reads two SPI absolute rotary encoders and maintains the current lat/lon positio
 
 Reads a quadrature rotary encoder wired to GPIO pins 18 and 17 — these are the encoder's two switch/channel outputs (A/B), not a clock/direction pair. Decoding happens entirely in the **kernel**, not in Python: `install.sh` adds `dtoverlay=rotary-encoder,pin_a=18,pin_b=17,relative_axis=1` to `/boot/firmware/config.txt`, which binds the stock `drivers/input/misc/rotary_encoder.c` driver to those two pins and does the gray-code decode into `EV_REL`/`REL_X` events.
 
-- `Dial._find_rotary_device()` locates the resulting `/dev/input/eventN` device via `evdev.list_devices()`, matching by capability (`EV_REL`/`REL_X` present, `EV_KEY` absent) rather than a hardcoded device name or event-number, so it survives reboots and eventN renumbering.
-- `start()` registers the device's file descriptor directly on the asyncio event loop with `loop.add_reader(fd, callback)` — no background task, no thread pool.
+- `start()` calls `Dial._find_rotary_device()`, which locates the resulting `/dev/input/eventN` device via `evdev.list_devices()`, matching by capability (`EV_REL`/`REL_X` present, `EV_KEY` absent) rather than a hardcoded device name or event-number, so it survives reboots and eventN renumbering — `__init__` itself never touches evdev.
+- `start()` then registers the device's file descriptor directly on the asyncio event loop with `loop.add_reader(fd, callback)` — no background task, no thread pool.
 - `_on_readable()` pushes `_POLARITY * sign(event.value)` onto `self.queue` (an `asyncio.Queue[int]`, via `put_nowait`) directly for each `REL_X` event — no accumulation or timer. A single `_POLARITY` constant corrects for physical wiring.
 - `stop()` calls `loop.remove_reader(fd)`, which is synchronous and immediate.
 - `main.py`'s `_dial_loop()` consumes `await self.dial.queue.get()` — the kernel-driver decode is entirely internal to `dial.py`.
@@ -400,13 +400,19 @@ Wraps `python-vlc` directly. Does not import from `streaming/`.
 ```python
 class AudioPlayer:
     def __init__(self):
+        self.instance = None
+        self.player = None
+        self.current_url = None
+
+    def start(self):
         self.instance = vlc.Instance(
             "--input-repeat=-1",
             "--network-caching=2000",
         )
         self.player = self.instance.media_player_new()
-        self.current_url = None
 ```
+
+The VLC instance/player are constructed in `start()`, not `__init__` — constructing an `AudioPlayer` never touches VLC (§4.14's `HardwareComponent` contract).
 
 - `play(url)` stops any current playback and starts the new URL immediately. VLC handles playlist URLs (`.m3u`, `.pls`) internally. It records `current_url` so `_monitor_stream` can detect when the user has moved to a new station. `AudioPlayer` only ever deals in URL strings — it has no concept of a "city" or "station"; callers extract the URL from `self.nav.state.station[1]` before calling.
 - `--input-repeat=-1` means VLC retries the stream automatically if the connection drops.
@@ -421,7 +427,7 @@ class AudioPlayer:
 
 Three LED channels (R=22, G=23, B=24), each driven via the kernel's `gpio-led`/`leds-gpio` driver + sysfs — the same kernel-driver approach `dial.py` (§4.6) and `buttons.py` (§4.7) use for their GPIO inputs.
 
-Each channel is controlled by writing `"1"`/`"0"` to `/sys/class/leds/<label>/brightness`, where `<label>` comes from `install.sh`'s `dtoverlay=gpio-led,gpio=<pin>,label=<label>` line. `RGBLed._resolve(label)` builds this path directly and does a one-time test write during `__init__`, converting a `PermissionError` into a `RuntimeError` that names the udev rule to check (see the permissions note below).
+Each channel is controlled by writing `"1"`/`"0"` to `/sys/class/leds/<label>/brightness`, where `<label>` comes from `install.sh`'s `dtoverlay=gpio-led,gpio=<pin>,label=<label>` line. `RGBLed.start()` resolves each label to a path via `_resolve(label)` and does a one-time test write, converting a `PermissionError` into a `RuntimeError` that names the udev rule to check (see the permissions note below) — `__init__` only stores the three labels, deferring the actual sysfs access to `start()` like every other HAL role.
 
 `max_brightness` is `1` for these LEDs — binary on/off only, no dimming.
 
@@ -485,7 +491,7 @@ If you need to understand the audio subsystem, read `audio_async.py`.
 
 Makes `App`'s logic (the dial/encoder event loops, LED-flash-on-event behavior, display/audio call sequencing) unit-testable off a Pi, and lets the base package install and import cleanly on any platform. Three files, none of which require changes to `dial.py`, `positional_encoders.py`, `buttons.py`, `rgb_led.py`, `display.py`, or `audio_async.py`:
 
-- **`protocols.py`** — one `typing.Protocol` per hardware role (`DialProtocol`, `PositionalEncodersProtocol`, `ButtonManagerProtocol`, `RGBLedProtocol`, `DisplayProtocol`, `AudioPlayerProtocol`), matching each real class's public method signatures exactly. `Protocol` uses structural typing, so the six real classes already satisfy these interfaces by shape alone — no inheritance required. A shared `HardwareComponent` base declares only `async def stop(self) -> None`, deliberately not `start()`: `RGBLed` and `AudioPlayer` have no `start()` at all (construction alone makes them ready), while the other four roles do, so each role protocol declares `start()` only where the concrete class has one.
+- **`protocols.py`** — one `typing.Protocol` per hardware role (`DialProtocol`, `PositionalEncodersProtocol`, `ButtonManagerProtocol`, `RGBLedProtocol`, `DisplayProtocol`, `AudioPlayerProtocol`), matching each real class's public method signatures exactly. `Protocol` uses structural typing, so the six real classes already satisfy these interfaces by shape alone — no inheritance required. A shared `HardwareComponent` base declares `def start(self) -> None` and `async def stop(self) -> None`: every concrete class defers real hardware I/O (device discovery, sysfs writes, opening an I2C bus, constructing a VLC instance) from `__init__` to `start()`, so constructing any of the six is always hardware-free — the same deferred-construction pattern `buttons.py`'s `Button` originated (§4.7).
 - **`fake.py`** — `FakeDial`, `FakePositionalEncoders`, `FakeButtonManager`, `FakeRGBLed`, `FakeDisplay`, `FakeAudioPlayer`. Each satisfies its Protocol and exposes simple test hooks (`push_turn()`, `set_position()`, `inject_event()`, `set_error()`, `.calls`/`.played`/`.buffer` recordings) that let a test drive `App`'s real event loops end-to-end with no real I/O. These fakes intentionally do **not** re-implement the real modules' internals (SPI parity checks, evdev capability matching, press/hold timing) — that stays covered separately, e.g. `tests/buttons_test.py`'s stub-and-test-the-real-class approach.
 - **`factory.py`** — `build_hardware()` constructs and returns the real, Pi-backed `(dial, audio_player, encoders, display, led)` tuple. The concrete hardware modules are imported inside its function body, not at module scope, so importing `radioglobe.hal` never pulls in `evdev`/`spidev`/`liquidcrystal_i2c`/`vlc` — only calling `build_hardware()` does.
 

--- a/src/radioglobe/audio_async.py
+++ b/src/radioglobe/audio_async.py
@@ -4,6 +4,11 @@ import logging
 
 class AudioPlayer:
     def __init__(self) -> None:
+        self.instance = None
+        self.player = None
+        self.current_url = None
+
+    def start(self) -> None:
         self.instance = vlc.Instance(
             "--input-repeat=-1",
             "--network-caching=2000",  # 2 s network buffer absorbs stream jitter
@@ -11,7 +16,6 @@ class AudioPlayer:
         if self.instance is None:
             raise RuntimeError("VLC failed to initialise — check VLC installation and options")
         self.player = self.instance.media_player_new()
-        self.current_url = None
 
     def play(self, url: str) -> None:
         """Play a new URL stream, stopping current playback if needed."""

--- a/src/radioglobe/audio_async.py
+++ b/src/radioglobe/audio_async.py
@@ -9,6 +9,7 @@ class AudioPlayer:
         self.current_url = None
 
     def start(self) -> None:
+        """Create the VLC instance and player."""
         self.instance = vlc.Instance(
             "--input-repeat=-1",
             "--network-caching=2000",  # 2 s network buffer absorbs stream jitter

--- a/src/radioglobe/dial.py
+++ b/src/radioglobe/dial.py
@@ -10,7 +10,7 @@ _POLARITY = 1  # flip to -1 if on-device verification shows inverted direction
 class Dial:
     def __init__(self) -> None:
         self.queue: asyncio.Queue[int] = asyncio.Queue()
-        self._device = self._find_rotary_device()
+        self._device = None
         self._loop = None
 
     @staticmethod
@@ -38,10 +38,12 @@ class Dial:
                     self.queue.put_nowait(_POLARITY * -1)
 
     def start(self) -> None:
+        self._device = self._find_rotary_device()
         self._loop = asyncio.get_running_loop()
         self._loop.add_reader(self._device.fd, self._on_readable)
 
     async def stop(self) -> None:
-        if self._loop is not None:
+        if self._loop is not None and self._device is not None:
             self._loop.remove_reader(self._device.fd)
-        self._device.close()
+        if self._device is not None:
+            self._device.close()

--- a/src/radioglobe/dial.py
+++ b/src/radioglobe/dial.py
@@ -38,6 +38,7 @@ class Dial:
                     self.queue.put_nowait(_POLARITY * -1)
 
     def start(self) -> None:
+        """Locate and open the rotary-encoder device."""
         self._device = self._find_rotary_device()
         self._loop = asyncio.get_running_loop()
         self._loop.add_reader(self._device.fd, self._on_readable)

--- a/src/radioglobe/display.py
+++ b/src/radioglobe/display.py
@@ -12,16 +12,17 @@ _DISPLAY_ROWS = 4
 
 class Display:
     def __init__(self) -> None:
-        self.lcd = liquidcrystal_i2c.LiquidCrystal_I2C(
-            _I2C_LCD_ADDR, _DISPLAY_I2C_PORT, numlines=_DISPLAY_ROWS
-        )
+        self.lcd = None
         self.buffer = ["" for _ in range(_DISPLAY_ROWS)]
         self.changed = asyncio.Event()
         self._task = None
-        logging.info("Display initialized")
 
     def start(self) -> None:
-        """Start the background display update loop."""
+        """Connect to the LCD and start the background display update loop."""
+        self.lcd = liquidcrystal_i2c.LiquidCrystal_I2C(
+            _I2C_LCD_ADDR, _DISPLAY_I2C_PORT, numlines=_DISPLAY_ROWS
+        )
+        logging.info("Display initialized")
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._display_loop())
             logging.info("Display loop started")

--- a/src/radioglobe/hal/fake.py
+++ b/src/radioglobe/hal/fake.py
@@ -138,7 +138,11 @@ class FakeRGBLed:
     def __init__(self) -> None:
         self.calls: list = []
         self.current_color: Optional[str] = None
+        self.started = False
         self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
 
     def set_color(self, color_name: str) -> None:
         self.current_color = color_name
@@ -202,6 +206,10 @@ class FakeAudioPlayer:
         self.volume = 100
         self._error = False
         self.stopped_calls = 0
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
 
     def play(self, url: str) -> None:
         self.current_url = url

--- a/src/radioglobe/hal/protocols.py
+++ b/src/radioglobe/hal/protocols.py
@@ -14,22 +14,20 @@ from radioglobe.coordinates import Coordinate
 
 
 class HardwareComponent(Protocol):
-    """Shared teardown shape common to all hardware roles.
+    """Shared start/stop shape common to all hardware roles.
 
-    Deliberately does NOT declare start() - RGBLed and AudioPlayer have no
-    start() at all (construction alone makes them ready; see rgb_led.py /
-    audio_async.py), while the other four roles do. Each role protocol
-    below declares start() only where the concrete class has one.
+    Every concrete class defers real hardware I/O (device discovery,
+    sysfs writes, opening an I2C bus, constructing a VLC instance) from
+    __init__ to start(), so constructing one is always hardware-free.
     """
 
+    def start(self) -> None: ...
     async def stop(self) -> None: ...
 
 
 @runtime_checkable
 class DialProtocol(HardwareComponent, Protocol):
     queue: "asyncio.Queue[int]"
-
-    def start(self) -> None: ...
 
 
 @runtime_checkable
@@ -43,14 +41,12 @@ class PositionalEncodersProtocol(HardwareComponent, Protocol):
     def is_latched(self) -> bool: ...
     def get_calibration(self) -> dict: ...
     def restore_calibration(self, state: dict) -> None: ...
-    def start(self) -> None: ...
 
 
 @runtime_checkable
 class ButtonManagerProtocol(HardwareComponent, Protocol):
     event_queue: "asyncio.Queue"
 
-    def start(self) -> None: ...
     async def handle_events(self) -> None: ...
     def get_event_nowait(self) -> Optional[tuple]: ...
 
@@ -66,7 +62,6 @@ class RGBLedProtocol(HardwareComponent, Protocol):
 class DisplayProtocol(HardwareComponent, Protocol):
     changed: asyncio.Event
 
-    def start(self) -> None: ...
     def message(
         self, line_1: str = "", line_2: str = "", line_3: str = "", line_4: str = ""
     ) -> None: ...

--- a/src/radioglobe/main.py
+++ b/src/radioglobe/main.py
@@ -37,7 +37,6 @@ class App:
     ):
         self.dial = dial
         self.audio_player = audio_player
-        self.audio_player.change_volume_level(DEFAULT_VOLUME)
         self.encoders = encoders
         self.display = display
         self.led = led
@@ -242,6 +241,9 @@ class App:
         self.dial.start()
         self.encoders.start()
         self.display.start()
+        self.led.start()
+        self.audio_player.start()
+        self.audio_player.change_volume_level(DEFAULT_VOLUME)
 
         button_manager = create_button_manager(
             jog=ButtonCallbacks(short_cb=self._handle_short_jog, press_cb=self._on_jog_press),
@@ -302,12 +304,8 @@ class App:
         finally:
             if self._stream_task and not self._stream_task.done():
                 self._stream_task.cancel()
-            # Reverse of the start order above (button_manager, display,
-            # encoders, dial). audio_player and led are appended even though
-            # they were never started — both accept stop() safely without a
-            # prior start(), since neither class has a start() at all (see
-            # rgb_led.py / audio_async.py).
-            for hw in [button_manager, self.display, self.encoders, self.dial, self.audio_player, self.led]:
+            # Reverse of the start order above.
+            for hw in [button_manager, self.audio_player, self.led, self.display, self.encoders, self.dial]:
                 await hw.stop()
 
 

--- a/src/radioglobe/positional_encoders.py
+++ b/src/radioglobe/positional_encoders.py
@@ -15,9 +15,7 @@ class PositionalEncoders:
         self.latitude_offset = latitude_offset
         self.longitude_offset = longitude_offset
         self.updated = asyncio.Event()
-
-        # Enable SPI
-        self.spi = spidev.SpiDev()
+        self.spi = None
 
         # Used to safely stop the task
         self._task = None
@@ -104,7 +102,6 @@ class PositionalEncoders:
     UNLATCH_CONFIRM_THRESHOLD = 2
 
     async def run_encoder(self) -> None:
-        # while self._running:
         unlatch_confirm_count = 0
         while self._task:
             readings = self.read_spi()
@@ -136,6 +133,7 @@ class PositionalEncoders:
             await asyncio.sleep(0.05)
 
     def start(self) -> None:
+        self.spi = spidev.SpiDev()
         self._task = asyncio.create_task(self.run_encoder())
 
     async def stop(self) -> None:

--- a/src/radioglobe/rgb_led.py
+++ b/src/radioglobe/rgb_led.py
@@ -47,6 +47,7 @@ class RGBLed:
         self._running = asyncio.Event()
 
     def start(self) -> None:
+        """Resolve and prepare the LED sysfs paths."""
         self.paths = {channel: self._resolve(label) for channel, label in self._labels.items()}
 
     @staticmethod

--- a/src/radioglobe/rgb_led.py
+++ b/src/radioglobe/rgb_led.py
@@ -42,12 +42,12 @@ class RGBLed:
 
     def __init__(self, red_label: str = _LED_LABEL_RED, green_label: str = _LED_LABEL_GREEN,
                  blue_label: str = _LED_LABEL_BLUE) -> None:
-        self.paths = {
-            "red": self._resolve(red_label),
-            "green": self._resolve(green_label),
-            "blue": self._resolve(blue_label),
-        }
+        self._labels = {"red": red_label, "green": green_label, "blue": blue_label}
+        self.paths: dict = {}
         self._running = asyncio.Event()
+
+    def start(self) -> None:
+        self.paths = {channel: self._resolve(label) for channel, label in self._labels.items()}
 
     @staticmethod
     def _resolve(label: str) -> Path:

--- a/tests/hal/fake_test.py
+++ b/tests/hal/fake_test.py
@@ -89,6 +89,13 @@ class TestFakeRGBLed(unittest.IsolatedAsyncioTestCase):
         self.assertIn(("flash", "blue", 0.0), led.calls)
         self.assertEqual(led.current_color, "off")
 
+    async def test_start_stop_toggle_flags(self):
+        led = FakeRGBLed()
+        led.start()
+        self.assertTrue(led.started)
+        await led.stop()
+        self.assertTrue(led.stopped)
+
 
 class TestFakeDisplay(unittest.TestCase):
     def test_message_updates_buffer_and_changed_event(self):
@@ -125,6 +132,11 @@ class TestFakeAudioPlayer(unittest.IsolatedAsyncioTestCase):
         await player.stop()
         await player.stop()
         self.assertEqual(player.stopped_calls, 2)
+
+    def test_start_sets_flag(self):
+        player = FakeAudioPlayer()
+        player.start()
+        self.assertTrue(player.started)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`Dial`, `RGBLed`, `Display`, `AudioPlayer`, and `PositionalEncoders` all touched real hardware in `__init__` (evdev device enumeration, sysfs writes, opening the I2C bus, constructing a VLC instance, constructing a `SpiDev`), contradicting the deferred-construction rationale `buttons.py`'s `Button` already documented and followed ("device discovery is deferred to `start()` ... so constructing a Button/ButtonManager never touches real hardware unless `start()` is actually called"). Moved each class's hardware setup into `start()`, matching `Button`'s pattern:

- `dial.py`: `Dial._find_rotary_device()` now runs in `start()`, not `__init__`.
- `rgb_led.py`: `RGBLed.__init__` now only stores the three sysfs labels; `start()` resolves them to paths and does the one-time test write.
- `display.py`: `Display.__init__` no longer constructs the I2C LCD object; `start()` does, then starts the display loop as before.
- `audio_async.py`: `AudioPlayer.__init__` no longer constructs the VLC instance/player; `start()` does. This reintroduces `start()` on `AudioPlayer`/`RGBLed` - removed as dead code in #30 when there was nothing to defer into it, now there is.
- `positional_encoders.py`: `PositionalEncoders.__init__` no longer constructs `spidev.SpiDev()`; `start()` does. Also dropped a stale `# while self._running:` comment referencing an attribute this class doesn't have.

**The one real blocker, resolved:** `App.__init__` (`main.py`) eagerly called `self.audio_player.change_volume_level(DEFAULT_VOLUME)` right after construction, before `start()` could ever run - this would've broken if `AudioPlayer`'s VLC setup moved to `start()`. Traced to commit `baa4e43` ("Initialise volume on startup", Jul 2025), from before the HAL abstraction existed. Volume isn't part of persisted/restored state (confirmed: `app_state.py`/`navigation.py` only save lat/lon/offsets/latch) and nothing depends on its timing, so the call moves into `run()`, right after the new `self.audio_player.start()`. `run()` also now calls `self.led.start()` alongside the existing `dial`/`encoders`/`display` start() calls. `App.__init__` is now fully hardware-I/O-free, even indirectly.

`hal/protocols.py`'s `HardwareComponent` re-absorbs `start()` now that all six roles share the shape again. `hal/fake.py`'s `FakeRGBLed`/`FakeAudioPlayer` gain matching `start()`/`started` tracking, with test coverage mirroring the other Fakes' existing start/stop tests. Added one-line docstrings to `Dial.start()`/`RGBLed.start()`/`AudioPlayer.start()` so all four newly-touched `start()` methods describe what they defer. `ARCHITECTURE.md` updated throughout to match.

Tenth and final item from the ranked HAL-layer audit (after #29-#36, released as v0.9.1). This one's a genuine behavior-timing change (not just internal reshuffling), so it's a good candidate for its own on-device verification pass before it's folded into a release.

## Test plan
- [x] `uv run pytest` — 73 passed (2 new: `FakeRGBLed`/`FakeAudioPlayer` start/stop flag tests)
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly
- [ ] On-device verification (recommended before release, given the startup-sequencing change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)