### PR TITLE
Fix dead RGBLed hardware-presence skip guards in integration scripts

### DIFF
--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -20,15 +20,14 @@ from radioglobe.hal.positional_encoders import PositionalEncoders
 from radioglobe.hal.rgb_led import RGBLed, COLOUR_RED
 from radioglobe.radio_config import STATIONS_JSON
 
+led = RGBLed()
 try:
-    RGBLed()
+    led.start()
 except RuntimeError as e:
     pytest.skip(str(e), allow_module_level=True)
 
 
 async def main(stickiness: int, fuzziness: int):
-    led = RGBLed()
-
     print("Starting up encoders...")
     encoders = PositionalEncoders()
     encoders.start()

--- a/tests/integration/streaming_cvlc_test.py
+++ b/tests/integration/streaming_cvlc_test.py
@@ -13,8 +13,9 @@ from radioglobe.hal.rgb_led import RGBLed, COLOUR_RED
 from radioglobe.radio_config import STATIONS_JSON
 from streaming.streaming_cvlc import StreamerCVLC
 
+led = RGBLed()
 try:
-    RGBLed()
+    led.start()
 except RuntimeError as e:
     pytest.skip(str(e), allow_module_level=True)
 
@@ -33,8 +34,6 @@ async def main():
     STICKINESS = 2
     FUZZINESS = 5
     AUDIO_SERVICE = "pulse"
-
-    led = RGBLed()
 
     print("Starting up encoders...")
     encoders = PositionalEncoders()


### PR DESCRIPTION
## Summary
`tests/integration/main_test.py` and `tests/integration/streaming_cvlc_test.py` both had a module-level `try: RGBLed() except RuntimeError: pytest.skip(...)` guard meant to skip the script when LED hardware/sysfs entries aren't present. PR #37 moved `RGBLed`'s sysfs resolve/write from `__init__` into `start()`, so bare `RGBLed()` construction stopped raising - the guard silently became dead code that could never trigger, flagged (not fixed) in #38.

Fix: construct the `RGBLed` once at module level and call `.start()` inside the `try`/`except` instead of just constructing it, then reuse that already-started instance later in each script's `main()` rather than constructing a second, never-started one.

## Test plan
- [x] `uv run pytest` — 73 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly
- [x] Both files confirmed to parse cleanly (`spidev` isn't available in this dev environment, so `pytest.importorskip` skips full collection here - the guard logic itself can only be exercised against real hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)