### PR TITLE
Reduce logging verbosity, make LOG_LEVEL overridable without a redeploy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -703,6 +703,26 @@ This is cosmetic and non-crashing, but the display momentarily shows the wrong c
 
 ---
 
+### Improvement C: State is lost on every routine deploy, not just a hard crash
+
+**Problem:** `App.save_state()` (`main.py`) is only ever called from `_handle_long_mid()`, the physical shutdown-button handler. There is no `SIGTERM`/`SIGINT` handler anywhere in the codebase, and `services/radioglobe.service` has no `KillSignal` override, so it uses the default `SIGTERM`. Python's default `SIGTERM` handling terminates the process immediately without running `run()`'s `finally:` block — so state is never saved there either. Net effect: every `systemctl restart` (i.e. every routine code deploy via `make update`) silently discards any city/station/mode/calibration change made since the device was last physically powered off via the button.
+
+**Fix (designed, not yet implemented):** register a signal handler for `SIGTERM`/`SIGINT` in `run()` that calls `save_state()` immediately, then cancels `_encoder_task`/`_dial_task` (promoted from local variables to instance attributes so the handler can reach them) to trigger the same graceful-shutdown path `KeyboardInterrupt` already uses — the existing `finally:` block's hardware cleanup runs either way. Widen `except KeyboardInterrupt:` to `except (KeyboardInterrupt, asyncio.CancelledError):`, since the signal-triggered cancellation surfaces as `CancelledError`. Deliberately scoped to the graceful-stop case only (a `systemctl restart` is exactly this); a true `SIGKILL`, crash, or power loss would still lose unsaved state, same as today. A broader fix (save proactively on every navigation/calibration change, debounced to avoid SD-card write bursts from rapid dial spinning) was also designed but set aside as more complexity than currently wanted.
+
+**Effort:** ~1 hour (signal handler + tests) for the scoped fix above.
+
+---
+
+### Improvement D: No `journalctl -p` priority filtering is possible
+
+**Problem:** Python's `logging` module levels (DEBUG/INFO/WARNING/etc.) aren't mapped to syslog priorities anywhere — the app uses a plain `StreamHandler` via `logging.basicConfig()`, and `services/radioglobe.service` has no `SyslogIdentifier=`. Every log line, regardless of Python level, lands in the systemd journal at the same undifferentiated priority. `journalctl -p warning` (or any `-p` filter) currently can't distinguish RadioGlobe's own warnings/errors from its routine output.
+
+**Fix:** add `systemd.journal.JournalHandler` (from the `systemd-python` package) as the logging handler instead of the default stream handler, which maps Python log levels to syslog priorities automatically. This is a new dependency — Pi-only, so it would go in `pyproject.toml`'s existing `pi` extras group rather than the base dependencies.
+
+**Effort:** ~30 minutes, plus on-device verification that `journalctl -p warning --user-unit=radioglobe.service` actually filters as expected.
+
+---
+
 ## 12. What's Already Good
 
 **`database.py` pure-function design.** All station and city lookups are stateless functions with no hardware dependencies. They're unit-testable without mocking anything and straightforward to reason about. The one-time index build at startup (`build_cities_index`, called from `Navigator.__init__` — §4.3) is the right trade-off — it makes every city lookup in `_encoder_loop()` O(1).

--- a/src/radioglobe/cli.py
+++ b/src/radioglobe/cli.py
@@ -8,7 +8,7 @@ from radioglobe.radio_config import LOG_LEVEL
 
 def main() -> None:
     logging.basicConfig(
-        format="%(asctime)s: %(message)s",
+        format="%(asctime)s %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
         level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
     )

--- a/src/radioglobe/hal/display.py
+++ b/src/radioglobe/hal/display.py
@@ -54,7 +54,7 @@ class Display:
         self.buffer[2] = line_3[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.buffer[3] = line_4[:_DISPLAY_COLUMNS].center(_DISPLAY_COLUMNS)
         self.changed.set()
-        logging.info(f"Message set: {[line_1, line_2, line_3, line_4]}")
+        logging.debug(f"Message set: {[line_1, line_2, line_3, line_4]}")
 
     def show_station(self, coords: Coordinate, city: str, station_name: str) -> None:
         """Show the current city and station."""

--- a/src/radioglobe/main.py
+++ b/src/radioglobe/main.py
@@ -84,6 +84,7 @@ class App:
         name, url = self.nav.state.station
         self.display.show_station(coords, self.nav.state.city, name)
         self.audio_player.play(url)
+        logging.info(f"🔊 Now playing: {name} ({self.nav.state.city})")
         return url
 
     async def _monitor_stream(self, expected_url: str):
@@ -134,19 +135,18 @@ class App:
             cities = self.nav.refresh_nearby_cities(coords)
 
             if not self.encoders.is_latched() and cities:
-                logging.debug(f"latch: {self.encoders.is_latched()} Cities: {cities}")
+                logging.debug(f"latch check: is_latched=False, {len(cities)} nearby cities")
                 asyncio.create_task(self.led.flash(COLOUR_GREEN, LED_FLASH_LONG))
 
                 self.encoders.latch(*coords, stickiness=STICKINESS)
-                logging.debug(f"Matching cities: stick:{STICKINESS} fuzz:{FUZZINESS} {cities} {self.encoders.is_latched()}")
+                logging.debug(f"Matching cities: stick:{STICKINESS} fuzz:{FUZZINESS} {len(cities)} candidates")
                 if not self.nav.select_city():
                     logging.warning(f"No stations for {self.nav.state.city!r} — skipping latch")
                     self.encoders.reset_latch()
                     continue
-                logging.info(f"Cities: {cities}")
                 logging.debug(
                     f"📻 Tuning to: city_idx:{self.nav.state.city_idx} "
-                    f"{self.nav.state.city} {self.nav.state.station}\n{self.nav.state.stations}"
+                    f"{self.nav.state.city} {self.nav.state.station}"
                 )
                 self._start_monitor_stream(self._play_station())
 
@@ -182,7 +182,7 @@ class App:
             idx, result = self.nav.state.station_idx, self.nav.state.stations
         else:
             idx, result = self.nav.state.city_idx, self.nav.state.cities
-        logging.debug(f"🖲️ Jog button short press! Change mode idx: {idx} {result}")
+        logging.debug(f"🖲️ Jog button short press! Change mode idx: {idx} ({len(result)} items)")
 
     async def _handle_long_jog(self):
         logging.debug("🖲️ Jog button long press: None")
@@ -288,10 +288,7 @@ class App:
                     self.display.show_status(STATUS_CALIBRATE)
                 else:
                     self._start_monitor_stream(self._play_station())
-                    logging.debug(
-                        f"Playing saved station: {self.nav.state.station} {self.nav.state.city} "
-                        f"{self.nav.state.cities} {self.nav.state.stations}"
-                    )
+                    logging.debug(f"Resumed saved station: {self.nav.state.station} {self.nav.state.city}")
             else:
                 self.display.show_status(STATUS_CALIBRATE)
 
@@ -317,7 +314,7 @@ if __name__ == "__main__":
     from radioglobe.hal.factory import build_hardware
 
     logging.basicConfig(
-        format="%(asctime)s: %(message)s",
+        format="%(asctime)s %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
         level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
     )

--- a/src/radioglobe/navigation.py
+++ b/src/radioglobe/navigation.py
@@ -50,7 +50,7 @@ class Navigator:
         PositionalEncoders object, since Navigator has no hardware
         dependency and can't read one directly.
         """
-        logging.debug(f"STATIONS: {self.state.stations}")
+        logging.debug(f"Saving state: city={self.state.city!r}, {len(self.state.stations)} stations")
         state = asdict(self.state)
         state.update(encoder_offsets)
         state["latch"] = True
@@ -112,7 +112,7 @@ class Navigator:
             logging.debug("⚠️ No stations available.")
             return
         self.state.station_idx = (self.state.station_idx + direction) % len(self.state.stations)
-        logging.debug(f"station_idx:{self.state.station_idx} {self.state.stations}")
+        logging.debug(f"station_idx:{self.state.station_idx} ({len(self.state.stations)} stations)")
         self.state.station = self.state.stations[self.state.station_idx]
         logging.debug(f"📻 Tuning to: station_idx:{self.state.station_idx} {self.state.station}")
 

--- a/src/radioglobe/radio_config.py
+++ b/src/radioglobe/radio_config.py
@@ -40,5 +40,5 @@ LED_FLASH_DIAL = 0.1    # dial turn feedback (brief since frequent)
 # State persistence
 STATE_CACHE_PATH = "~/cache/radioglobe.json"
 
-# Logging
-LOG_LEVEL = "DEBUG"
+# Logging - override without a redeploy via RADIOGLOBE_LOG_LEVEL=DEBUG + restart
+LOG_LEVEL = os.environ.get("RADIOGLOBE_LOG_LEVEL", "INFO")


### PR DESCRIPTION
## Summary
`LOG_LEVEL` was hardcoded to `"DEBUG"` in `radio_config.py` — too verbose for production by default, and required editing source + redeploying to change. Several DEBUG calls also dumped entire station/city lists on routine events, and two INFO calls fired repeatedly during normal operation rather than just at boot, with no level shown in the log format to tell severity apart at a glance.

- `LOG_LEVEL` now reads `RADIOGLOBE_LOG_LEVEL` (default `"INFO"`), mirroring the existing `RADIOGLOBE_STATIONS` override pattern already in the same file. A debugging session is now `RADIOGLOBE_LOG_LEVEL=DEBUG` + restart, no redeploy needed.
- Log format now includes `%(levelname)s`, so severity is visible in `journalctl` output (`cli.py` and `main.py`'s `__main__` block).
- Trimmed ~6 DEBUG calls that dumped full `stations`/`cities` lists down to counts or the single relevant item (`navigation.py`, `main.py`).
- `hal/display.py`'s `message()` no longer logs the full 4-line buffer at INFO on every screen update — moved to DEBUG.
- `main.py`'s per-latch `"Cities: {cities}"` INFO dump removed outright, superseded by a new, more useful INFO line: `_play_station()` now logs `"Now playing: {name} ({city})"` — the single method all three playback triggers (encoder latch, dial change, startup resume) go through, giving a clean default-level narrative of what the device has actually played.

Also recorded (`ARCHITECTURE.md` §11) two related findings from the same full-project review that were designed but deferred rather than implemented now: the state-loss-on-deploy bug (no `SIGTERM` handler, so `systemctl restart` discards unsaved state) and the lack of `journalctl -p` priority filtering (nothing maps Python log levels to syslog priorities today).

## Test plan
- [x] `uv run pytest` — 73 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly
- [ ] On-device: confirm `journalctl -f` output is now short/readable during normal use, and `RADIOGLOBE_LOG_LEVEL=DEBUG` + restart brings back full detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)