### PR TITLE
Enable journalctl -p priority filtering via SysLogHandler

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -713,16 +713,6 @@ This is cosmetic and non-crashing, but the display momentarily shows the wrong c
 
 ---
 
-### Improvement D: No `journalctl -p` priority filtering is possible
-
-**Problem:** Python's `logging` module levels (DEBUG/INFO/WARNING/etc.) aren't mapped to syslog priorities anywhere — the app uses a plain `StreamHandler` via `logging.basicConfig()`, and `services/radioglobe.service` has no `SyslogIdentifier=`. Every log line, regardless of Python level, lands in the systemd journal at the same undifferentiated priority. `journalctl -p warning` (or any `-p` filter) currently can't distinguish RadioGlobe's own warnings/errors from its routine output.
-
-**Fix:** add `systemd.journal.JournalHandler` (from the `systemd-python` package) as the logging handler instead of the default stream handler, which maps Python log levels to syslog priorities automatically. This is a new dependency — Pi-only, so it would go in `pyproject.toml`'s existing `pi` extras group rather than the base dependencies.
-
-**Effort:** ~30 minutes, plus on-device verification that `journalctl -p warning --user-unit=radioglobe.service` actually filters as expected.
-
----
-
 ## 12. What's Already Good
 
 **`database.py` pure-function design.** All station and city lookups are stateless functions with no hardware dependencies. They're unit-testable without mocking anything and straightforward to reason about. The one-time index build at startup (`build_cities_index`, called from `Navigator.__init__` — §4.3) is the right trade-off — it makes every city lookup in `_encoder_loop()` O(1).
@@ -738,3 +728,5 @@ This is cosmetic and non-crashing, but the display momentarily shows the wrong c
 **Display update coalescing.** The buffer + `asyncio.Event` pattern in `display.py` correctly batches rapid updates. I2C is slow (~100µs per byte); writing all 4 LCD lines takes several milliseconds, so coalescing is not just an optimisation — it's necessary for responsiveness.
 
 **The systemd user service** (not system service) is the correct approach for an application that uses PulseAudio. PulseAudio runs per-user; a system service cannot see the user's audio session. Running as the logged-in user (with `loginctl enable-linger`) is the only reliable way to get auto-detected audio outputs including Bluetooth.
+
+**`journalctl -p` priority filtering** (`cli.py`) uses the stdlib `logging.handlers.SysLogHandler` pointed at `/dev/log` rather than the `systemd-python` package — `systemd-python` has no prebuilt wheels anywhere and needs `libsystemd-dev` to build even just to resolve lock metadata, which broke `uv run` on a plain dev machine with no Pi-specific tooling installed. `systemd-journald` already speaks syslog on `/dev/log` and maps the syslog priority `SysLogHandler` derives from the Python log level into the journal's own `PRIORITY` field, so `journalctl -p warning` filters correctly with zero new dependencies and identical behavior on-device and off. Falls back to the previous plain stderr format if `/dev/log` isn't available (e.g. a non-systemd host).

--- a/src/radioglobe/cli.py
+++ b/src/radioglobe/cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import logging.handlers
 
 from radioglobe.hal.factory import build_hardware
 from radioglobe.main import App
@@ -7,11 +8,23 @@ from radioglobe.radio_config import LOG_LEVEL
 
 
 def main() -> None:
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)s: %(message)s",
-        datefmt="%H:%M:%S",
-        level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
-    )
+    level = getattr(logging, LOG_LEVEL.upper(), logging.INFO)
+    try:
+        # systemd-journald speaks syslog on /dev/log and maps the syslog
+        # priority (which SysLogHandler derives from the Python level) into
+        # the journal's own PRIORITY field, so `journalctl -p <level>` can
+        # filter meaningfully - no extra dependency needed. journald owns
+        # the timestamp, so it's left out of the format here.
+        handler = logging.handlers.SysLogHandler(address="/dev/log")
+        handler.setFormatter(logging.Formatter("radioglobe: %(levelname)s %(message)s"))
+        logging.basicConfig(handlers=[handler], level=level)
+    except OSError:
+        # /dev/log not available (e.g. off-Pi dev, non-systemd host).
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s: %(message)s",
+            datefmt="%H:%M:%S",
+            level=level,
+        )
 
     logging.info("Starting RadioGlobe...")
 


### PR DESCRIPTION
## Summary
Every log line, regardless of Python level, landed in the systemd journal at the same undifferentiated priority — `journalctl -p warning` couldn't distinguish RadioGlobe's own warnings from routine output. `ARCHITECTURE.md`'s Improvement D suggested `systemd-python` (`JournalHandler`) for this.

**Tried that first, hit a real problem:** `systemd-python` has no prebuilt wheels anywhere and needs `libsystemd-dev` to build even just to resolve lock metadata. Adding it to `pyproject.toml`'s `pi` extra broke `uv run pytest`/`ruff check` in a plain dev sandbox with no Pi-specific tooling installed. A `platform_machine == 'aarch64' or platform_machine == 'armv7l'` marker restricting it to ARM didn't help either — `uv`'s universal lock still needs metadata for that branch regardless of the current host, so it tried to build it anyway and failed the same way.

**Switched to the stdlib `logging.handlers.SysLogHandler`** pointed at `/dev/log` instead. `systemd-journald` already speaks syslog on that socket and maps the syslog priority — which `SysLogHandler` derives from the Python log level automatically — into the journal's own `PRIORITY` field. Zero new dependencies, works identically on-device and off.

**Verified locally** (this dev sandbox has `/dev/log` too, being systemd-based): sent INFO and WARNING messages through the exact handler config, confirmed `journalctl -t radioglobe -p warning` returned only the warning while `-p info` returned both, and journald correctly picked up `radioglobe` as the syslog identifier from the message prefix — before ever touching the real device.

Falls back to the existing plain stderr format via a caught `OSError` if `/dev/log` isn't available (e.g. a non-systemd host).

`ARCHITECTURE.md` updated: removed Improvement D from Suggested Improvements (implemented now, not just designed) and added a note to §12 What's Already Good explaining the approach and why `systemd-python` was rejected.

## Test plan
- [x] `uv run pytest` — 73 passed
- [x] `uv run ruff check` — all checks passed
- [x] `make build` — wheel builds cleanly
- [x] Verified locally: `journalctl -p` filtering confirmed working via a direct smoke test before touching the Pi
- [ ] On-device: confirm `journalctl --user-unit=radioglobe.service -p warning` filters correctly against the real service

🤖 Generated with [Claude Code](https://claude.com/claude-code)