### PR TITLE
Fix broken device-version target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,5 +101,5 @@ clean:
 # Check version on device
 # -----------------------------
 device-version:
-	@echo "Device version:" \
-	@ssh $(REMOTE) "cd $(REMOTE_DIR) && cat VERSION"
+	@echo -n "Device version: "
+	@ssh $(REMOTE) 'cat /opt/radioglobe/VERSION 2>/dev/null || /opt/radioglobe/venv/bin/python -c "import importlib.metadata as m; print(m.version(\"radioglobe\"))"'


### PR DESCRIPTION
## Summary
- `device-version`'s trailing backslash joined the `echo` and `ssh` recipe lines into one shell command, so `ssh`'s output was silently swallowed and its literal `@ssh ...` text got printed as extra `echo` arguments instead.
- It also read `VERSION` from `$(REMOTE_DIR)` (`~/RadioGlobe`), which no longer exists on-device now that `make deploy`'s fast path writes to `/opt/radioglobe/VERSION` directly. Switched to that path with the same `importlib.metadata` fallback `force-deploy` already uses.

## Test plan
- [x] `make device-version` now prints `Device version: 0.9.6`, matching `cat /opt/radioglobe/VERSION` on the live device.