### PR TITLE
Drop dead pyproject.toml sed step from set-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,8 @@ bump-major:
 set-version:
 	@NEW_VERSION=$$(cat .new_version); \
 	echo $$NEW_VERSION > VERSION; \
-	sed -i "s/^version = \".*\"/version = \"$$NEW_VERSION\"/" $(VERSION_FILE); \
 	rm .new_version; \
-	git add VERSION $(VERSION_FILE); \
+	git add VERSION; \
 	git commit -m "Release v$$NEW_VERSION"; \
 	git tag v$$NEW_VERSION
 


### PR DESCRIPTION
## Summary
- `set-version` referenced `$(VERSION_FILE)`, a make variable never defined anywhere in the Makefile, so it expanded to empty and the `sed -i` call failed with "no input files" every time - silently, since the recipe chains commands with `;` (not `&&`, no `set -e`), so the commit/tag still went through regardless.
- Versioning is dynamic via `setuptools_scm` (`pyproject.toml` has no static `version = "..."` line to match anyway), so there's nothing for the sed step to do. Dropped it - `set-version` now just bumps `VERSION` and commits/tags it, which is the part that actually worked.

## Test plan
- [x] Read through `bump-patch` -> `set-version` chain to confirm the remaining steps (VERSION write, git add/commit/tag) are unaffected.
- Not run end-to-end (`make bump-patch` would create a real commit/tag) - these targets are already known-unused since v0.7.0 per the release notes in CHANGELOG.md; this is a correctness cleanup, not a re-adoption of the bump-* flow.