### PR TITLE
Warn when update.sh falls back to installing from source

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -36,6 +36,16 @@ if [ -d "$SRC_DIR/dist" ] && ls "$SRC_DIR/dist/radioglobe-"*.whl >/dev/null 2>&1
     echo "📦 Installing wheel: $WHEEL"
     $RADIOGLOBE_DIR/venv/bin/pip install --upgrade "$WHEEL[pi]"
 else
+    # No wheel staged: falls back to installing whatever is currently
+    # checked out in $SRC_DIR, which is only as fresh as the last time
+    # someone pulled here. Surface that instead of installing it silently.
+    echo "⚠️  No staged wheel in $SRC_DIR/dist — installing from the source"
+    echo "⚠️  tree instead. This ships whatever is currently checked out"
+    echo "⚠️  here, not necessarily your latest changes — run 'git pull' in"
+    echo "⚠️  $SRC_DIR first, or use 'make deploy' to build+ship a fresh wheel."
+    if git -C "$SRC_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "📌 Installing from commit: $(git -C "$SRC_DIR" log -1 --format='%h %cd %s' --date=short)"
+    fi
     echo "📦 Installing from source: $SRC_DIR"
     $RADIOGLOBE_DIR/venv/bin/pip install --upgrade "$SRC_DIR[pi]"
 fi


### PR DESCRIPTION
## Summary
- `update.sh`'s no-staged-wheel fallback installs from the on-device source tree (`$SRC_DIR`), which is only as fresh as the last `git pull` run there - not guaranteed current. This happened silently before, so a bare `make update` with nothing staged in `dist/` could quietly reinstall stale code.
- Added a clear warning plus the commit being installed (when `$SRC_DIR` is a git checkout), pointing at `make deploy` as the alternative. No prompt/blocking, since `update.sh` needs to keep running non-interactively over SSH.

## Test plan
- [x] `bash -n update.sh` - syntax check passes.
- [x] Reviewed diff - only adds echo/git-log lines ahead of the existing fallback install command; doesn't change control flow or the wheel-staged happy path.